### PR TITLE
style: fix format after conflicts

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
-  "printWidth": 120,
+  "printWidth": 95,
   "tabWidth": 2
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "lib": "ng build entity-state",
-    "format": "prettier --write {src,projects}/**/*.{ts,js,html,scss}"
+    "format": "prettier --write \"{src,projects}/**/*.{ts,js,html,scss}\""
   },
   "private": true,
   "dependencies": {

--- a/projects/entity-state/src/lib/actions/create-or-replace.ts
+++ b/projects/entity-state/src/lib/actions/create-or-replace.ts
@@ -1,7 +1,7 @@
-import {Type} from '@angular/core';
-import {EntityState} from '../entity-state';
-import {generateActionObject} from '../internal';
-import {Payload} from './type-alias';
+import { Type } from '@angular/core';
+import { EntityState } from '../entity-state';
+import { generateActionObject } from '../internal';
+import { Payload } from './type-alias';
 
 export type EntityCreateOrReplaceAction<T> = Payload<T | T[]>;
 

--- a/projects/entity-state/src/lib/entity-state.ts
+++ b/projects/entity-state/src/lib/entity-state.ts
@@ -1,5 +1,5 @@
-import {Type} from '@angular/core';
-import {StateContext} from '@ngxs/store';
+import { Type } from '@angular/core';
+import { StateContext } from '@ngxs/store';
 import {
   EntityAddAction,
   EntityCreateOrReplaceAction,
@@ -10,9 +10,9 @@ import {
   EntityUpdateAction,
   EntityUpdateActiveAction
 } from './actions';
-import {InvalidIdError, NoActiveEntityError, NoSuchEntityError} from './errors';
-import {IdStrategy} from './id-strategy';
-import {getActive, HashMap} from './internal';
+import { InvalidIdError, NoActiveEntityError, NoSuchEntityError } from './errors';
+import { IdStrategy } from './id-strategy';
+import { getActive, HashMap } from './internal';
 import IdGenerator = IdStrategy.IdGenerator;
 
 /**
@@ -45,23 +45,33 @@ export type StateSelector<T> = (state: EntityStateModel<any>) => T;
 
 // @dynamic
 export abstract class EntityState<T> {
-
   private readonly idKey: string;
   private readonly storePath: string;
   protected readonly idGenerator: IdGenerator<T>;
 
-  protected constructor(storeClass: Type<EntityState<T>>, _idKey: keyof T, idStrategy: Type<IdGenerator<T>>) {
+  protected constructor(
+    storeClass: Type<EntityState<T>>,
+    _idKey: keyof T,
+    idStrategy: Type<IdGenerator<T>>
+  ) {
     this.idKey = _idKey as string;
     this.storePath = storeClass['NGXS_META'].path;
     this.idGenerator = new idStrategy(_idKey);
 
-    this.setup(storeClass,
-      'add', 'createOrReplace',
-      'update', 'updateActive',
-      'remove', 'removeActive',
-      'setLoading', 'setError',
-      'setActive', 'clearActive',
-      'reset');
+    this.setup(
+      storeClass,
+      'add',
+      'createOrReplace',
+      'update',
+      'updateActive',
+      'remove',
+      'removeActive',
+      'setLoading',
+      'setError',
+      'setActive',
+      'clearActive',
+      'reset'
+    );
   }
 
   private static get staticStorePath(): string {
@@ -89,7 +99,7 @@ export abstract class EntityState<T> {
    */
   static get activeId(): StateSelector<string> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return subState.active;
     };
@@ -100,7 +110,7 @@ export abstract class EntityState<T> {
    */
   static get active(): StateSelector<any> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return getActive(subState);
     };
@@ -111,7 +121,7 @@ export abstract class EntityState<T> {
    */
   static get keys(): StateSelector<string[]> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return Object.keys(subState.entities);
     };
@@ -122,7 +132,7 @@ export abstract class EntityState<T> {
    */
   static get entities(): StateSelector<any[]> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return subState.ids.map(id => subState.entities[id]);
     };
@@ -131,9 +141,10 @@ export abstract class EntityState<T> {
   /**
    * Returns a selector for the nth entity, sorted by insertion order
    */
-  static nthEntity(index: number): StateSelector<any> { // tslint:disable-line:member-ordering
+  static nthEntity(index: number): StateSelector<any> {
+    // tslint:disable-line:member-ordering
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       const id = subState.ids[index];
       return subState.entities[id];
@@ -143,9 +154,10 @@ export abstract class EntityState<T> {
   /**
    * Returns a selector for paginated entities, sorted by insertion order
    */
-  static paginatedEntities(size: number, page: number): StateSelector<any[]> { // tslint:disable-line:member-ordering
+  static paginatedEntities(size: number, page: number): StateSelector<any[]> {
+    // tslint:disable-line:member-ordering
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return subState.ids
         .slice(page * size, (page + 1) * size)
@@ -158,7 +170,7 @@ export abstract class EntityState<T> {
    */
   static get entitiesMap(): StateSelector<HashMap<any>> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return subState.entities;
     };
@@ -169,7 +181,7 @@ export abstract class EntityState<T> {
    */
   static get size(): StateSelector<number> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return Object.keys(subState.entities).length;
     };
@@ -180,7 +192,7 @@ export abstract class EntityState<T> {
    */
   static get error(): StateSelector<Error | undefined> {
     const that = this;
-    return (state) => {
+    return state => {
       const name = that.staticStorePath;
       return elvis(state, name).error;
     };
@@ -191,7 +203,7 @@ export abstract class EntityState<T> {
    */
   static get loading(): StateSelector<boolean> {
     const that = this;
-    return (state) => {
+    return state => {
       const name = that.staticStorePath;
       return elvis(state, name).loading;
     };
@@ -202,7 +214,7 @@ export abstract class EntityState<T> {
    */
   static get latest(): StateSelector<any> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       const latestId = subState.ids[subState.ids.length - 1];
       return subState.entities[latestId];
@@ -214,7 +226,7 @@ export abstract class EntityState<T> {
    */
   static get latestId(): StateSelector<string | undefined> {
     const that = this;
-    return (state) => {
+    return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
       return subState.ids[subState.ids.length - 1];
     };
@@ -225,26 +237,37 @@ export abstract class EntityState<T> {
   // a new entity (unless there was an error) will be added
   // if the entity provides an existing ID, an error will be thrown
   // In all cases it will do entity[idKey] = id;
-  add({getState, patchState}: StateContext<EntityStateModel<T>>, {payload}: EntityAddAction<T>) {
-    const updated = this._upsert(getState(), payload,
+  add(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntityAddAction<T>
+  ) {
+    const updated = this._upsert(
+      getState(),
+      payload,
       // for automated ID strategies this won't throw an error
       // for IdStrategy.FROM_ENTITY it will throw an error if no ID is present
       (p, state) => this.idGenerator.generateId(p, state)
     );
-    patchState({...updated});
+    patchState({ ...updated });
   }
 
   // TODO: payload type, add actions
   // if a valid ID is present or can be generated it will use that and create/replace without error
-  createOrReplace({getState, patchState}: StateContext<EntityStateModel<T>>, {payload}: EntityCreateOrReplaceAction<T>) {
-    const updated = this._upsert(getState(), payload,
-      (p, state) => this.idGenerator.getPresentIdOrGenerate(p, state)
+  createOrReplace(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntityCreateOrReplaceAction<T>
+  ) {
+    const updated = this._upsert(getState(), payload, (p, state) =>
+      this.idGenerator.getPresentIdOrGenerate(p, state)
     );
-    patchState({...updated});
+    patchState({ ...updated });
   }
 
-  update({getState, patchState}: StateContext<EntityStateModel<T>>, {payload}: EntityUpdateAction<T>) {
-    let entities = {...getState().entities}; // create copy
+  update(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntityUpdateAction<T>
+  ) {
+    let entities = { ...getState().entities }; // create copy
 
     let affected: T[];
 
@@ -267,33 +290,39 @@ export abstract class EntityState<T> {
       });
     }
 
-    patchState({entities});
+    patchState({ entities });
   }
 
-  updateActive({getState, patchState}: StateContext<EntityStateModel<T>>, {payload}: EntityUpdateActiveAction<T>) {
+  updateActive(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntityUpdateActiveAction<T>
+  ) {
     const state = getState();
-    const {id, active} = mustGetActive(state);
-    const {entities} = state;
+    const { id, active } = mustGetActive(state);
+    const { entities } = state;
 
     if (typeof payload === 'function') {
-      patchState({entities: {...this._update(entities, payload(active), id)}});
+      patchState({ entities: { ...this._update(entities, payload(active), id) } });
     } else {
-      patchState({entities: {...this._update(entities, payload, id)}});
+      patchState({ entities: { ...this._update(entities, payload, id) } });
     }
   }
 
-  removeActive({getState, patchState}: StateContext<EntityStateModel<T>>) {
-    const {entities, ids, active} = getState();
+  removeActive({ getState, patchState }: StateContext<EntityStateModel<T>>) {
+    const { entities, ids, active } = getState();
     delete entities[active];
     patchState({
-      entities: {...entities},
+      entities: { ...entities },
       ids: ids.filter(id => id !== active),
       active: undefined
     });
   }
 
-  remove({getState, patchState}: StateContext<EntityStateModel<T>>, {payload}: EntityRemoveAction<T>) {
-    const {entities, ids, active} = getState();
+  remove(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntityRemoveAction<T>
+  ) {
+    const { entities, ids, active } = getState();
 
     if (payload === null) {
       patchState({
@@ -302,46 +331,62 @@ export abstract class EntityState<T> {
         active: undefined
       });
     } else {
-      const deleteIds: string[] = typeof payload === 'function' ?
-        Object.values(entities).filter(e => payload(e)).map(e => this.idOf(e)) :
-        Array.isArray(payload) ? payload as string[] : [payload] as string[];
+      const deleteIds: string[] =
+        typeof payload === 'function'
+          ? Object.values(entities)
+              .filter(e => payload(e))
+              .map(e => this.idOf(e))
+          : Array.isArray(payload)
+          ? (payload as string[])
+          : ([payload] as string[]);
 
       const wasActive = deleteIds.includes(active);
       deleteIds.forEach(id => delete entities[id]);
       patchState({
-        entities: {...entities},
+        entities: { ...entities },
         ids: ids.filter(id => !deleteIds.includes(id)),
         active: wasActive ? undefined : active
       });
     }
   }
 
-  reset({setState}: StateContext<EntityStateModel<T>>) {
+  reset({ setState }: StateContext<EntityStateModel<T>>) {
     setState(defaultEntityState());
   }
 
-  setLoading({patchState}: StateContext<EntityStateModel<T>>, {payload}: EntitySetLoadingAction) {
-    patchState({loading: payload});
+  setLoading(
+    { patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntitySetLoadingAction
+  ) {
+    patchState({ loading: payload });
   }
 
-  setActive({patchState}: StateContext<EntityStateModel<T>>, {payload}: EntitySetActiveAction) {
-    patchState({active: payload});
+  setActive(
+    { patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntitySetActiveAction
+  ) {
+    patchState({ active: payload });
   }
 
-  clearActive({patchState}: StateContext<EntityStateModel<T>>) {
-    patchState({active: undefined});
+  clearActive({ patchState }: StateContext<EntityStateModel<T>>) {
+    patchState({ active: undefined });
   }
 
-  setError({patchState}: StateContext<EntityStateModel<T>>, {payload}: EntitySetErrorAction) {
-    patchState({error: payload});
+  setError(
+    { patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: EntitySetErrorAction
+  ) {
+    patchState({ error: payload });
   }
 
   // ------------------- UTILITY -------------------
 
-  private _upsert(state: EntityStateModel<T>,
-                  payload: Partial<T> | Partial<T>[],
-                  generateId: (payload: Partial<T>, state: EntityStateModel<T>) => string): Partial<EntityStateModel<T>> {
-    const {entities, ids} = state;
+  private _upsert(
+    state: EntityStateModel<T>,
+    payload: Partial<T> | Partial<T>[],
+    generateId: (payload: Partial<T>, state: EntityStateModel<T>) => string
+  ): Partial<EntityStateModel<T>> {
+    const { entities, ids } = state;
     asArray(payload).forEach(entity => {
       const id = generateId(entity, state);
       entity[this.idKey] = id;
@@ -352,7 +397,7 @@ export abstract class EntityState<T> {
     });
 
     return {
-      entities: {...entities},
+      entities: { ...entities },
       ids: [...ids]
     };
   }
@@ -387,21 +432,22 @@ export abstract class EntityState<T> {
     // TODO: assertValidId here every time?
     return data[this.idKey];
   }
-
 }
 
-function mustGetActive<T>(state: EntityStateModel<T>): { id: string, active: T } {
+function mustGetActive<T>(state: EntityStateModel<T>): { id: string; active: T } {
   const active = getActive(state);
   if (active === undefined) {
     throw new NoActiveEntityError();
   }
-  return {id: state.active, active};
+  return { id: state.active, active };
 }
 
 function elvis(object: any, path: string) {
-  return path ? path.split('.').reduce(function (value, key) {
-    return value && value[key];
-  }, object) : object;
+  return path
+    ? path.split('.').reduce(function(value, key) {
+        return value && value[key];
+      }, object)
+    : object;
 }
 
 function asArray<T>(input: T | T[]): T[] {

--- a/projects/entity-state/src/lib/errors.ts
+++ b/projects/entity-state/src/lib/errors.ts
@@ -18,7 +18,9 @@ export class NoSuchEntityError extends EntityStateError {
 
 export class InvalidIdError extends EntityStateError {
   constructor(passedId: string, calculatedId: string) {
-    super(`Unable to use passed or calculated ID. Passed: ${passedId}, idOf(entity): ${calculatedId}`);
+    super(
+      `Unable to use passed or calculated ID. Passed: ${passedId}, idOf(entity): ${calculatedId}`
+    );
   }
 }
 

--- a/projects/entity-state/src/lib/id-strategy.spec.ts
+++ b/projects/entity-state/src/lib/id-strategy.spec.ts
@@ -1,6 +1,11 @@
-import {EntityIdGenerator, IdGenerator, IncrementingIdGenerator, UUIDGenerator} from './id-strategy';
-import {EntityStateModel} from './entity-state';
-import {InvalidIdOfError} from './errors';
+import {
+  EntityIdGenerator,
+  IdGenerator,
+  IncrementingIdGenerator,
+  UUIDGenerator
+} from './id-strategy';
+import { EntityStateModel } from './entity-state';
+import { InvalidIdOfError } from './errors';
 
 describe('ID generator', () => {
   function getImplementations(): IdGenerator<Todo>[] {
@@ -33,7 +38,7 @@ describe('ID generator', () => {
         '3': {
           id: '3',
           title: 'Todo 3'
-        },
+        }
       }
     };
   }
@@ -47,15 +52,15 @@ describe('ID generator', () => {
 
   it('should get the ID of given entity', () => {
     getImplementations().forEach(generator => {
-      expect(generator.getIdOf({id: '0', title: 'Todo 0'})).toBe('0');
-      expect(generator.getIdOf({title: 'Todo 0'})).toBe(undefined);
+      expect(generator.getIdOf({ id: '0', title: 'Todo 0' })).toBe('0');
+      expect(generator.getIdOf({ title: 'Todo 0' })).toBe(undefined);
     });
   });
 
   it('should throw an error if ID is required but undefined', () => {
     getImplementations().forEach(generator => {
       try {
-        generator.mustGetIdOf({title: 'Todo 0'});
+        generator.mustGetIdOf({ title: 'Todo 0' });
       } catch (e) {
         expect(e.message).toBe(new InvalidIdOfError().message);
       }
@@ -64,35 +69,38 @@ describe('ID generator', () => {
   });
 
   it('should get ID from given entity if present or generate new one', () => {
-    [new IncrementingIdGenerator<Todo>('id'), new UUIDGenerator<Todo>('id')].forEach(generator => {
-      expect(generator.getPresentIdOrGenerate({id: '0', title: 'Todo 0'}, getState())).toBe('0');
-      expect(generator.getPresentIdOrGenerate({title: 'Todo 0'}, getState())).toBeTruthy();
-    });
+    [new IncrementingIdGenerator<Todo>('id'), new UUIDGenerator<Todo>('id')].forEach(
+      generator => {
+        expect(
+          generator.getPresentIdOrGenerate({ id: '0', title: 'Todo 0' }, getState())
+        ).toBe('0');
+        expect(generator.getPresentIdOrGenerate({ title: 'Todo 0' }, getState())).toBeTruthy();
+      }
+    );
 
     const entityGenerator = new EntityIdGenerator<Todo>('id');
-    expect(entityGenerator.getPresentIdOrGenerate({id: '0', title: 'Todo 0'}, getState())).toBe('0');
+    expect(
+      entityGenerator.getPresentIdOrGenerate({ id: '0', title: 'Todo 0' }, getState())
+    ).toBe('0');
     try {
-      entityGenerator.getPresentIdOrGenerate({title: 'Todo 0'}, getState());
+      entityGenerator.getPresentIdOrGenerate({ title: 'Todo 0' }, getState());
     } catch (e) {
       expect(e.message).toBe(new InvalidIdOfError().message);
     }
   });
 
   describe('IncrementingIdGenerator', () => {
-
     it('should generate correct IDs from beginning', () => {
       const generator = new IncrementingIdGenerator<Todo>('id');
       const state = getState();
       expect(generator.isIdInState('3', state)).toBe(true); // current highest ID
       expect(generator.generateId(undefined, state)).toBe('4');
-      state.ids.push("4"); // use the generated ID
+      state.ids.push('4'); // use the generated ID
       expect(generator.generateId(undefined, state)).toBe('5');
     });
-
   });
 
   describe('UUIDGenerator', () => {
-
     it('should generate correct UUIDs', () => {
       const generator = new UUIDGenerator<Todo>('id');
       const state = getState(); // while this state doesn't have valid UUIDs, it's not possible to provoke a collision anyways
@@ -102,21 +110,24 @@ describe('ID generator', () => {
       expect(secondId.length).toBe(36);
       expect(firstId).not.toEqual(secondId);
     });
-
   });
 
   describe('EntityIdGenerator', () => {
-
     it('should take correct IDs from entities', () => {
       const generator = new EntityIdGenerator<Todo>('id');
       const state = getState();
-      expect(generator.generateId({
-        id: '4',
-        title: 'Todo 4'
-      }, state)).toBe('4');
+      expect(
+        generator.generateId(
+          {
+            id: '4',
+            title: 'Todo 4'
+          },
+          state
+        )
+      ).toBe('4');
 
       try {
-        generator.generateId({title: 'Todo 0'}, state);
+        generator.generateId({ title: 'Todo 0' }, state);
       } catch (e) {
         expect(e.message).toBe(new InvalidIdOfError().message);
       }
@@ -124,11 +135,8 @@ describe('ID generator', () => {
         title: "Todo 0"
       }, undefined)).toThrow(new InvalidIdOfError());*/
     });
-
   });
-
 });
-
 
 interface Todo {
   id: string;

--- a/projects/entity-state/src/lib/id-strategy.ts
+++ b/projects/entity-state/src/lib/id-strategy.ts
@@ -1,10 +1,9 @@
-import {EntityStateModel} from './entity-state';
-import {InvalidIdOfError, ProvidedIdAlreadyExistsError} from './errors';
+import { EntityStateModel } from './entity-state';
+import { InvalidIdOfError, ProvidedIdAlreadyExistsError } from './errors';
 
 export namespace IdStrategy {
   export abstract class IdGenerator<T> {
-    protected constructor(protected readonly idKey: keyof T) {
-    }
+    protected constructor(protected readonly idKey: keyof T) {}
 
     abstract generateId(entity: Partial<T>, state: EntityStateModel<any>): string;
 
@@ -14,9 +13,7 @@ export namespace IdStrategy {
 
     getPresentIdOrGenerate(entity: Partial<T>, state: EntityStateModel<any>): string {
       const presentId = this.getIdOf(entity);
-      return presentId === undefined ?
-        this.generateId(entity, state) :
-        presentId;
+      return presentId === undefined ? this.generateId(entity, state) : presentId;
     }
 
     mustGetIdOf(entity: any): string {
@@ -56,10 +53,11 @@ export namespace IdStrategy {
       return nextId;
     }
 
-    private uuidv4(): string { // https://stackoverflow.com/a/2117523
-      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-        const r = Math.random() * 16 | 0; // tslint:disable-line
-        const v = c === 'x' ? r : (r & 0x3 | 0x8); // tslint:disable-line
+    private uuidv4(): string {
+      // https://stackoverflow.com/a/2117523
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        const r = (Math.random() * 16) | 0; // tslint:disable-line
+        const v = c === 'x' ? r : (r & 0x3) | 0x8; // tslint:disable-line
         return v.toString(16);
       });
     }
@@ -78,5 +76,4 @@ export namespace IdStrategy {
       return id;
     }
   }
-
 }

--- a/projects/entity-state/src/lib/internal.ts
+++ b/projects/entity-state/src/lib/internal.ts
@@ -14,7 +14,11 @@ export interface HashMap<T> {
  * @param store The class of the targeted entity state, e.g. ZooState
  * @param payload The payload for the created action object
  */
-export function generateActionObject<T>(fn: string, store: Type<EntityState<T>>, payload?: any) {
+export function generateActionObject<T>(
+  fn: string,
+  store: Type<EntityState<T>>,
+  payload?: any
+) {
   const name = store['NGXS_META'].path;
   const ReflectedAction = function(data: T) {
     this.payload = data;

--- a/projects/entity-state/src/test.ts
+++ b/projects/entity-state/src/test.ts
@@ -4,7 +4,10 @@ import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
 
 declare const require: any;
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,14 +1,19 @@
 <!--The content below is only a placeholder and can be replaced.-->
 <div style="text-align:center">
-  <h1>Welcome to ngxs-entity-store! <ng-container *ngIf="(loading$ | async)">loading ...</ng-container></h1>
+  <h1>
+    Welcome to ngxs-entity-store!
+    <ng-container *ngIf="(loading$ | async)">loading ...</ng-container>
+  </h1>
 </div>
 
-<button (click)="toggleLoading()">Toggle Loading</button> <button (click)="addToDo()">Add ToDo</button>
+<button (click)="toggleLoading()">Toggle Loading</button>
+<button (click)="addToDo()">Add ToDo</button>
 <h2>Your ToDos (total: {{ count$ | async }})</h2>
 <ng-container *ngIf="(toDos$ | async) as toDos">
   <ul>
     <li *ngFor="let toDo of toDos">
-      {{ toDo.title }} ({{ toDo.done ? '' : 'not ' }}done) <button (click)="open(toDo.title)">Open</button>
+      {{ toDo.title }} ({{ toDo.done ? '' : 'not ' }}done)
+      <button (click)="open(toDo.title)">Open</button>
       <button *ngIf="!toDo.done" (click)="setDone(toDo)">Done</button>
       <button (click)="removeToDo(toDo.title)">Remove</button>
     </li>
@@ -17,13 +22,18 @@
   <button (click)="removeFirstThree(toDos)">Remove first three</button>
   <button (click)="setOddDone()">Set odd done</button>
   <button (click)="updateDescription()">Update finished descriptions with "Done"</button>
-  <button (click)="removeAllDones()">Remove all dones</button> <button (click)="clearEntities()">Remove all</button>
+  <button (click)="removeAllDones()">Remove all dones</button>
+  <button (click)="clearEntities()">Remove all</button>
 </ng-container>
 
-<div *ngIf="(active$ | async) as active" style="margin: 16px; border: 1px solid; border-radius: 3px; padding: 16px;">
+<div
+  *ngIf="(active$ | async) as active"
+  style="margin: 16px; border: 1px solid; border-radius: 3px; padding: 16px;"
+>
   <h3>{{ active.title }} ({{ active.done ? '' : 'not ' }}done)</h3>
   <p>{{ active.description }}</p>
-  <button (click)="setDoneActive()">Done</button> <button (click)="closeDetails()">Close</button>
+  <button (click)="setDoneActive()">Done</button>
+  <button (click)="closeDetails()">Close</button>
 </div>
 <br /><br />
 <code>Active: {{ active$ | async | json }}</code

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,8 +1,8 @@
-import {ComponentFixture, ComponentFixtureAutoDetect, TestBed} from '@angular/core/testing';
-import {Store} from '@ngxs/store';
-import {defaultEntityState, NoActiveEntityError} from 'entity-state';
-import {AppComponent} from './app.component';
-import {AppModule} from './app.module';
+import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
+import { Store } from '@ngxs/store';
+import { defaultEntityState, NoActiveEntityError } from 'entity-state';
+import { AppComponent } from './app.component';
+import { AppModule } from './app.module';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -11,14 +11,14 @@ describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [AppModule],
-      providers: [{provide: ComponentFixtureAutoDetect, useValue: true}]
+      providers: [{ provide: ComponentFixtureAutoDetect, useValue: true }]
     });
 
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;
 
     const store = TestBed.get(Store);
-    store.reset({todo: defaultEntityState()});
+    store.reset({ todo: defaultEntityState() });
   });
 
   it('should add a todo', () => {
@@ -56,7 +56,7 @@ describe('AppComponent', () => {
     component.addToDo();
     component.setDone({
       title: 'NGXS Entity Store 1',
-      description: 'Doesn\'t matter. Just need title for ID',
+      description: "Doesn't matter. Just need title for ID",
       done: false
     });
 
@@ -220,7 +220,11 @@ describe('AppComponent', () => {
     component.addToDo(); // NGXS Entity Store 3
     component.addToDo(); // NGXS Entity Store 4
     component.addToDo(); // NGXS Entity Store 5
-    component.removeMultiple(['NGXS Entity Store 1', 'NGXS Entity Store 2', 'NGXS Entity Store 3']);
+    component.removeMultiple([
+      'NGXS Entity Store 1',
+      'NGXS Entity Store 2',
+      'NGXS Entity Store 3'
+    ]);
 
     component.toDos$.subscribe(([first]) => {
       expect(first.title).toBe('NGXS Entity Store 4');
@@ -394,7 +398,6 @@ describe('AppComponent', () => {
   });
 
   it('should select nth entities', () => {
-
     const count = 10;
     for (let i = 0; i < count; i++) {
       component.addToDo();
@@ -405,5 +408,4 @@ describe('AppComponent', () => {
       expect(toDo.title).toEqual('NGXS Entity Store ' + (i + 1));
     }
   });
-
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,7 +22,6 @@ import { ToDo, TodoState } from './store/todo';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-
   @Select(TodoState.size) count$: Observable<number>;
   @Select(TodoState.entities) toDos$: Observable<ToDo[]>;
   @Select(TodoState.active) active$: Observable<ToDo>;
@@ -37,8 +36,7 @@ export class AppComponent {
   private loading = false;
   private error = false;
 
-  constructor(private store: Store) {
-  }
+  constructor(private store: Store) {}
 
   toggleLoading() {
     this.loading = !this.loading;
@@ -54,25 +52,34 @@ export class AppComponent {
   }
 
   setDone(toDo: ToDo) {
-    this.store.dispatch(new Update(TodoState, toDo.title, {
-      done: true
-    }));
+    this.store.dispatch(
+      new Update(TodoState, toDo.title, {
+        done: true
+      })
+    );
   }
 
   setOddDone() {
-    this.store.dispatch(new Update(TodoState,
-      (e => parseInt(e.title.substring(18), 10) % 2 === 1), // select all ToDos with odd suffix
-      {done: true} // set them done
-    ));
+    this.store.dispatch(
+      new Update(
+        TodoState,
+        e => parseInt(e.title.substring(18), 10) % 2 === 1, // select all ToDos with odd suffix
+        { done: true } // set them done
+      )
+    );
   }
 
   updateDescription() {
-    this.store.dispatch(new Update(TodoState,
-      (e => e.done), // select all done ToDos
-      (e => { // custom update function: Update their description
-        return { ...e, description: e.description + ' -- This is done!'};
-      })
-    ));
+    this.store.dispatch(
+      new Update(
+        TodoState,
+        e => e.done, // select all done ToDos
+        e => {
+          // custom update function: Update their description
+          return { ...e, description: e.description + ' -- This is done!' };
+        }
+      )
+    );
   }
 
   closeDetails() {
@@ -81,13 +88,17 @@ export class AppComponent {
 
   toggleError() {
     this.error = !this.error;
-    this.store.dispatch(new SetError(TodoState, this.error ? new Error('Example error') : undefined));
+    this.store.dispatch(
+      new SetError(TodoState, this.error ? new Error('Example error') : undefined)
+    );
   }
 
   setDoneActive() {
-    this.store.dispatch(new UpdateActive(TodoState, {
-      done: true
-    }));
+    this.store.dispatch(
+      new UpdateActive(TodoState, {
+        done: true
+      })
+    );
   }
 
   open(title: string) {
@@ -109,29 +120,35 @@ export class AppComponent {
   }
 
   addToDo() {
-    this.store.dispatch(new Add(TodoState, {
-      title: 'NGXS Entity Store ' + (++this.counter),
-      description: 'Some Descr' + this.counter,
-      done: false
-    }));
+    this.store.dispatch(
+      new Add(TodoState, {
+        title: 'NGXS Entity Store ' + ++this.counter,
+        description: 'Some Descr' + this.counter,
+        done: false
+      })
+    );
   }
 
   doneAll() {
-    this.store.dispatch(new Update(
-      TodoState,
-      null, // select all -- TODO: add alias?
-      {done: true}
-    ));
+    this.store.dispatch(
+      new Update(
+        TodoState,
+        null, // select all -- TODO: add alias?
+        { done: true }
+      )
+    );
   }
 
   // --------- for tests ---------
 
   createOrReplace(title: string) {
-    this.store.dispatch(new CreateOrReplace(TodoState, {
-      title,
-      description: 'Some Descr' + title,
-      done: false
-    }));
+    this.store.dispatch(
+      new CreateOrReplace(TodoState, {
+        title,
+        description: 'Some Descr' + title,
+        done: false
+      })
+    );
   }
 
   resetState() {
@@ -139,15 +156,14 @@ export class AppComponent {
   }
 
   updateMultiple() {
-    this.store.dispatch(new Update(TodoState,
-      ['NGXS Entity Store 1', 'NGXS Entity Store 2'],
-      {done: true}
-    ));
+    this.store.dispatch(
+      new Update(TodoState, ['NGXS Entity Store 1', 'NGXS Entity Store 2'], { done: true })
+    );
   }
 
   addMultiple() {
-    this.store.dispatch(new Add(TodoState,
-      [
+    this.store.dispatch(
+      new Add(TodoState, [
         {
           title: 'NGXS Entity Store 1',
           description: 'Some Descr 1',
@@ -158,14 +174,17 @@ export class AppComponent {
           description: 'Some Descr 2',
           done: false
         }
-      ]
-    ));
+      ])
+    );
   }
 
   updateActiveWithFn(): Observable<any> {
-    return this.store.dispatch(new UpdateActive(TodoState,
-      (e => ({ ...e, description: e.description + ' -- Updated with Fn'}))
-    ));
+    return this.store.dispatch(
+      new UpdateActive(TodoState, e => ({
+        ...e,
+        description: e.description + ' -- Updated with Fn'
+      }))
+    );
   }
 
   removeActive() {

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -1,18 +1,14 @@
-import {NgModule} from '@angular/core';
-import {NgxsModule} from '@ngxs/store';
-import {TodoState} from './todo';
-import {NgxsLoggerPluginModule} from '@ngxs/logger-plugin';
+import { NgModule } from '@angular/core';
+import { NgxsModule } from '@ngxs/store';
+import { TodoState } from './todo';
+import { NgxsLoggerPluginModule } from '@ngxs/logger-plugin';
 
 const states = [TodoState];
 
 @NgModule({
-  imports: [
-    NgxsModule.forRoot(states),
-    NgxsLoggerPluginModule.forRoot()
-  ],
+  imports: [NgxsModule.forRoot(states), NgxsLoggerPluginModule.forRoot()],
   exports: [NgxsModule],
   declarations: [],
-  providers: [],
+  providers: []
 })
-export class StoreModule {
-}
+export class StoreModule {}

--- a/src/app/store/todo/index.ts
+++ b/src/app/store/todo/index.ts
@@ -1,1 +1,1 @@
-export * from "./store";
+export * from './store';

--- a/src/app/store/todo/store.ts
+++ b/src/app/store/todo/store.ts
@@ -1,5 +1,5 @@
-import {State} from '@ngxs/store';
-import {defaultEntityState, EntityStateModel, EntityState, IdStrategy} from 'entity-state';
+import { State } from '@ngxs/store';
+import { defaultEntityState, EntityStateModel, EntityState, IdStrategy } from 'entity-state';
 
 export interface ToDo {
   title: string;
@@ -12,13 +12,11 @@ export interface ToDo {
   defaults: defaultEntityState()
 })
 export class TodoState extends EntityState<ToDo> {
-
   constructor() {
-    super(TodoState, "title", IdStrategy.EntityIdGenerator);
+    super(TodoState, 'title', IdStrategy.EntityIdGenerator);
   }
 
   onUpdate(current: Readonly<ToDo>, updated: Partial<ToDo>): ToDo {
-    return {...current, ...updated};
+    return { ...current, ...updated };
   }
-
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,14 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>EntityStateIntegration</title>
-  <base href="/">
+  <head>
+    <meta charset="utf-8" />
+    <title>EntityStateIntegration</title>
+    <base href="/" />
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,5 +8,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
   .catch(err => console.error(err));

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -59,11 +59,11 @@
  * user can disable parts of macroTask/DomEvents patch by setting following flags
  */
 
- // (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
- // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
- // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
+// (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+// (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
+// (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
 
- /*
+/*
  * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
  * with the following flag, it will bypass `zone.js` patch for IE/Edge
  */
@@ -72,8 +72,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
-
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/test.ts
+++ b/src/test.ts
@@ -10,10 +10,7 @@ import {
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
- Fixes the prettier format caused by merge conflicts.
- Apply new formatting width of 95.
- Use double quotes for format script glob pattern.