### PR TITLE
feat: moved pagination to state

### DIFF
--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -379,22 +379,22 @@ describe('AppComponent', () => {
       return arr;
     };
 
-    for (let i = 0; i < 13; i++) {
+    for (let i = 0; i < 23; i++) {
       component.addToDo();
     }
 
-    const firstPage = component.getPaginatedEntities(5, 0).map(t => t.title);
-    const secondPage = component.getPaginatedEntities(5, 1).map(t => t.title);
-    const lastPage = component.getPaginatedEntities(5, 2).map(t => t.title);
+    const firstPage = component.getPaginatedEntities(10, 0).map(t => t.title);
+    const secondPage = component.getPaginatedEntities(10, 1).map(t => t.title);
+    const lastPage = component.getPaginatedEntities(10, 2).map(t => t.title);
 
-    expect(firstPage.length).toBe(5);
-    expect(firstPage).toEqual(generateTitles(1, 5));
+    expect(firstPage.length).toBe(10);
+    expect(firstPage).toEqual(generateTitles(1, 10));
 
-    expect(secondPage.length).toBe(5);
-    expect(secondPage).toEqual(generateTitles(6, 10));
+    expect(secondPage.length).toBe(10);
+    expect(secondPage).toEqual(generateTitles(11, 20));
 
     expect(lastPage.length).toBe(3);
-    expect(lastPage).toEqual(generateTitles(11, 13));
+    expect(lastPage).toEqual(generateTitles(21, 23));
   });
 
   it('should select nth entities', () => {

--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -1,8 +1,14 @@
-import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  ComponentFixtureAutoDetect,
+  TestBed
+} from '@angular/core/testing';
 import { Store } from '@ngxs/store';
 import { defaultEntityState, NoActiveEntityError } from '@ngxs-labs/entity-state';
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
+import { map } from 'rxjs/operators';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -370,7 +376,7 @@ describe('AppComponent', () => {
     });
   });
 
-  it('should paginate entities', () => {
+  it('should paginate entities', async(() => {
     const generateTitles = (from: number, to: number): string[] => {
       const arr = [];
       for (; from <= to; from++) {
@@ -383,19 +389,30 @@ describe('AppComponent', () => {
       component.addToDo();
     }
 
-    const firstPage = component.getPaginatedEntities(10, 0).map(t => t.title);
-    const secondPage = component.getPaginatedEntities(10, 1).map(t => t.title);
-    const lastPage = component.getPaginatedEntities(10, 2).map(t => t.title);
+    component
+      .getPaginatedEntities(10, 0)
+      .pipe(map(todos => todos.map(t => t.title)))
+      .subscribe(first => {
+        expect(first.length).toBe(10);
+        expect(first).toEqual(generateTitles(1, 10));
+      });
 
-    expect(firstPage.length).toBe(10);
-    expect(firstPage).toEqual(generateTitles(1, 10));
+    component
+      .getPaginatedEntities(10, 1)
+      .pipe(map(todos => todos.map(t => t.title)))
+      .subscribe(second => {
+        expect(second.length).toBe(10);
+        expect(second).toEqual(generateTitles(11, 20));
+      });
 
-    expect(secondPage.length).toBe(10);
-    expect(secondPage).toEqual(generateTitles(11, 20));
-
-    expect(lastPage.length).toBe(3);
-    expect(lastPage).toEqual(generateTitles(21, 23));
-  });
+    component
+      .getPaginatedEntities(10, 2)
+      .pipe(map(todos => todos.map(t => t.title)))
+      .subscribe(last => {
+        expect(last.length).toBe(3);
+        expect(last).toEqual(generateTitles(21, 23));
+      });
+  }));
 
   it('should select nth entities', () => {
     const count = 10;

--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@ngxs-labs/entity-state';
 import { Observable } from 'rxjs';
 import { ToDo, TodoState } from './store/todo';
+import { mergeMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -193,12 +194,10 @@ export class AppComponent {
     this.store.dispatch(new RemoveActive(TodoState));
   }
 
-  getPaginatedEntities(size: number, page: number): ToDo[] {
-    this.store.dispatch([
-      new SetPageSize(TodoState, size),
-      new GoToPage(TodoState, { page: page })
-    ]);
-    return this.store.selectSnapshot(TodoState.paginatedEntities);
+  getPaginatedEntities(size: number, page: number): Observable<ToDo[]> {
+    return this.store
+      .dispatch([new SetPageSize(TodoState, size), new GoToPage(TodoState, { page })])
+      .pipe(mergeMap(() => this.store.selectOnce(TodoState.paginatedEntities)));
   }
 
   getNthEntity(index: number): ToDo {

--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -4,12 +4,14 @@ import {
   Add,
   ClearActive,
   CreateOrReplace,
+  GoToPage,
   Remove,
   RemoveActive,
   Reset,
   SetActive,
   SetError,
   SetLoading,
+  SetPageSize,
   Update,
   UpdateActive
 } from '@ngxs-labs/entity-state';
@@ -192,7 +194,11 @@ export class AppComponent {
   }
 
   getPaginatedEntities(size: number, page: number): ToDo[] {
-    return this.store.selectSnapshot(TodoState.paginatedEntities(size, page));
+    this.store.dispatch([
+      new SetPageSize(TodoState, size),
+      new GoToPage(TodoState, { page: page })
+    ]);
+    return this.store.selectSnapshot(TodoState.paginatedEntities);
   }
 
   getNthEntity(index: number): ToDo {

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -7,3 +7,4 @@ export * from './active';
 export * from './error';
 export * from './reset';
 export * from './type-alias';
+export * from './pagination';

--- a/src/lib/actions/pagination.ts
+++ b/src/lib/actions/pagination.ts
@@ -9,7 +9,7 @@ export type GoToPagePayload =
   | { prev: true; wrap?: boolean }
   | { last: true }
   | { first: true };
-export type GoToPageAction = Payload<GoToPagePayload & { wrap: boolean }>;
+export type EntityGoToPageAction = Payload<GoToPagePayload & { wrap: boolean }>;
 
 export class GoToPage {
   /**
@@ -23,7 +23,7 @@ export class GoToPage {
   }
 }
 
-export type SetPageSizeAction = Payload<number>;
+export type EntitySetPageSizeAction = Payload<number>;
 
 export class SetPageSize {
   /**

--- a/src/lib/actions/pagination.ts
+++ b/src/lib/actions/pagination.ts
@@ -13,7 +13,8 @@ export type GoToPageAction = Payload<GoToPagePayload & { wrap: boolean }>;
 
 export class GoToPage {
   /**
-   * Generates an action that changes the page index for pagination
+   * Generates an action that changes the page index for pagination.
+   * Page index starts at 0.
    * @param target The targeted state class
    * @param payload Payload to change the page index
    */

--- a/src/lib/actions/pagination.ts
+++ b/src/lib/actions/pagination.ts
@@ -1,0 +1,36 @@
+import { Payload } from './type-alias';
+import { Type } from '@angular/core';
+import { EntityState } from '../entity-state';
+import { generateActionObject } from '../internal';
+
+export type GoToPagePayload =
+  | { page: number }
+  | { next: true; wrap?: boolean }
+  | { prev: true; wrap?: boolean }
+  | { last: true }
+  | { first: true };
+export type GoToPageAction = Payload<GoToPagePayload & { wrap: boolean }>;
+
+export class GoToPage {
+  /**
+   * Generates an action that changes the page index for pagination
+   * @param target The targeted state class
+   * @param payload Payload to change the page index
+   */
+  constructor(target: Type<EntityState<any>>, payload: GoToPagePayload) {
+    return generateActionObject('goToPage', target, { wrap: false, ...payload });
+  }
+}
+
+export type SetPageSizeAction = Payload<number>;
+
+export class SetPageSize {
+  /**
+   * Generates an action that changes the page size
+   * @param target The targeted state class
+   * @param payload The page size
+   */
+  constructor(target: Type<EntityState<any>>, payload: number) {
+    return generateActionObject('setPageSize', target, payload);
+  }
+}

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -424,7 +424,7 @@ export abstract class EntityState<T> {
   }
 
   setPageSize(
-    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntitySetPageSizeAction
   ) {
     patchState({ pageSize: payload });

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -19,6 +19,7 @@ import {
 import { IdStrategy } from './id-strategy';
 import { getActive, HashMap } from './internal';
 import IdGenerator = IdStrategy.IdGenerator;
+import { GoToPageAction, SetPageSizeAction } from './actions/pagination';
 
 /**
  * Interface for an EntityState.
@@ -30,6 +31,8 @@ export interface EntityStateModel<T> {
   error: Error | undefined;
   active: string | undefined;
   ids: string[];
+  pageSize: number;
+  pageIndex: number;
 }
 
 /**
@@ -42,7 +45,9 @@ export function defaultEntityState(): EntityStateModel<any> {
     ids: [],
     loading: false,
     error: undefined,
-    active: undefined
+    active: undefined,
+    pageSize: 10,
+    pageIndex: 0
   };
 }
 
@@ -75,7 +80,9 @@ export abstract class EntityState<T> {
       'setError',
       'setActive',
       'clearActive',
-      'reset'
+      'reset',
+      'goToPage',
+      'setPageSize'
     );
   }
 
@@ -159,13 +166,14 @@ export abstract class EntityState<T> {
   /**
    * Returns a selector for paginated entities, sorted by insertion order
    */
-  static paginatedEntities(size: number, page: number): StateSelector<any[]> {
+  static get paginatedEntities(): StateSelector<any[]> {
     // tslint:disable-line:member-ordering
     const that = this;
     return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
-      return subState.ids
-        .slice(page * size, (page + 1) * size)
+      const { ids, pageIndex, pageSize } = subState;
+      return ids
+        .slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
         .map(id => subState.entities[id]);
     };
   }
@@ -388,6 +396,39 @@ export abstract class EntityState<T> {
     patchState({ error: payload });
   }
 
+  goToPage(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: GoToPageAction
+  ) {
+    if ('page' in payload) {
+      patchState({ pageIndex: payload.page });
+      return;
+    } else if (payload['first']) {
+      patchState({ pageIndex: 0 });
+      return;
+    }
+
+    const { entities, pageSize, pageIndex } = getState();
+    const totalSize = Object.keys(entities).length;
+    const maxIndex = Math.floor(totalSize / pageSize);
+
+    if ('last' in payload) {
+      patchState({ pageIndex: maxIndex });
+    } else {
+      const step = payload['prev'] ? -1 : 1;
+      let index = pageIndex + step;
+      index = wrapOrClamp(payload.wrap, index, 0, maxIndex);
+      patchState({ pageIndex: index });
+    }
+  }
+
+  setPageSize(
+    { getState, patchState }: StateContext<EntityStateModel<T>>,
+    { payload }: SetPageSizeAction
+  ) {
+    patchState({ pageSize: payload });
+  }
+
   // ------------------- UTILITY -------------------
 
   /**
@@ -490,4 +531,34 @@ function elvis(object: any, path: string): any | undefined {
  */
 function asArray<T>(input: T | T[]): T[] {
   return Array.isArray(input) ? input : [input];
+}
+
+/**
+ * Limits a number to the given boundaries
+ * @param value The input value
+ * @param min The minimum value
+ * @param max The maximum value
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Uses the clamp function is wrap is false.
+ * Else it wrap to the max or min value respectively.
+ * @param wrap Flag to indicate if value should be wrapped
+ * @param value The input value
+ * @param min The minimum value
+ * @param max The maximum value
+ */
+function wrapOrClamp(wrap: boolean, value: number, min: number, max: number): number {
+  if (!wrap) {
+    return clamp(value, min, max);
+  } else if (value < min) {
+    return max;
+  } else if (value > max) {
+    return min;
+  } else {
+    return value;
+  }
 }

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -3,10 +3,12 @@ import { StateContext } from '@ngxs/store';
 import {
   EntityAddAction,
   EntityCreateOrReplaceAction,
+  EntityGoToPageAction,
   EntityRemoveAction,
   EntitySetActiveAction,
   EntitySetErrorAction,
   EntitySetLoadingAction,
+  EntitySetPageSizeAction,
   EntityUpdateAction,
   EntityUpdateActiveAction
 } from './actions';
@@ -19,7 +21,6 @@ import {
 import { IdStrategy } from './id-strategy';
 import { getActive, HashMap } from './internal';
 import IdGenerator = IdStrategy.IdGenerator;
-import { GoToPageAction, SetPageSizeAction } from './actions/pagination';
 
 /**
  * Interface for an EntityState.
@@ -398,7 +399,7 @@ export abstract class EntityState<T> {
 
   goToPage(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
-    { payload }: GoToPageAction
+    { payload }: EntityGoToPageAction
   ) {
     if ('page' in payload) {
       patchState({ pageIndex: payload.page });
@@ -424,7 +425,7 @@ export abstract class EntityState<T> {
 
   setPageSize(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
-    { payload }: SetPageSizeAction
+    { payload }: EntitySetPageSizeAction
   ) {
     patchState({ pageSize: payload });
   }

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -409,8 +409,8 @@ export abstract class EntityState<T> {
       return;
     }
 
-    const { entities, pageSize, pageIndex } = getState();
-    const totalSize = Object.keys(entities).length;
+    const { pageSize, pageIndex, ids } = getState();
+    const totalSize = ids.length;
     const maxIndex = Math.floor(totalSize / pageSize);
 
     if ('last' in payload) {

--- a/src/tests/id-strategy.spec.ts
+++ b/src/tests/id-strategy.spec.ts
@@ -20,6 +20,8 @@ describe('ID generator', () => {
       active: undefined,
       error: undefined,
       loading: false,
+      pageIndex: 0,
+      pageSize: 10,
       ids: ['0', '1', '2', '3'],
       entities: {
         '0': {


### PR DESCRIPTION
Moved pagination to state itself. Change pagination state with `GoToPage` and `SetPageSize`.
Automatically select correctly paginated entities with `EntityState.paginatedEntities`