### PR TITLE
fix: vscode path resolve

### DIFF
--- a/integration/tsconfig.app.json
+++ b/integration/tsconfig.app.json
@@ -1,15 +1,5 @@
 {
   "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "paths": {
-      "@ngxs-labs/entity-state": [
-        "src"
-      ],
-      "@ngxs-labs/entity-state/*": [
-        "src/*"
-      ]
-    }
-  },
   "exclude": [
     "test.ts",
     "**/*.spec.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,11 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "paths": {
+      "@ngxs-labs/entity-state": [
+        "src"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Everything works fine, except that VSCode is highlighting the imports from the library.

Related to: https://github.com/ngxs/store/pull/734