### PR TITLE
refactor: internal clean up

### DIFF
--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -117,8 +117,6 @@ export class AppComponent {
   }
 
   clearEntities() {
-    // TODO: select all with null ?
-    // Akita does it this way. I like it because you have to explicitly say so
     this.store.dispatch(new Remove(TodoState, null));
   }
 
@@ -136,7 +134,7 @@ export class AppComponent {
     this.store.dispatch(
       new Update(
         TodoState,
-        null, // select all -- TODO: add alias?
+        null, // select all
         { done: true }
       )
     );

--- a/src/lib/actions/active.ts
+++ b/src/lib/actions/active.ts
@@ -37,7 +37,6 @@ export class RemoveActive {
   }
 }
 
-// TODO: Confirm behaviour
 export class UpdateActive<T> {
   /**
    * Generates an action that will update the current active entity.

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -538,8 +538,13 @@ export abstract class EntityState<T> {
     });
   }
 
-  protected idOf(data: Partial<T>): string {
-    // TODO: assertValidId here every time?
+  /**
+   * Returns the id of the given entity, based on the defined idKey.
+   * This methods allows Partial entities and thus might return undefined.
+   * Other methods calling this one have to handle this case themselves.
+   * @param data a partial entity
+   */
+  protected idOf(data: Partial<T>): string | undefined {
     return data[this.idKey];
   }
 }

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -12,17 +12,11 @@ import {
   EntityUpdateAction,
   EntityUpdateActiveAction
 } from './actions';
-import {
-  InvalidIdError,
-  NoMatchingActionHandlerError,
-  NoSuchEntityError,
-  UpdateFailedError
-} from './errors';
+import { InvalidIdError, NoSuchEntityError, UpdateFailedError } from './errors';
 import { IdStrategy } from './id-strategy';
 import {
   asArray,
   elvis,
-  EntityActionHandler,
   EntityActionType,
   getActive,
   HashMap,
@@ -262,7 +256,6 @@ export abstract class EntityState<T> {
    * For certain ID strategies this might fail, if it provides an existing ID.
    * In all cases it will overwrite the ID value in the entity with the calculated ID.
    */
-  @EntityActionHandler
   add(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntityAddAction<T>
@@ -283,7 +276,6 @@ export abstract class EntityState<T> {
    * If it does the current entity will be replaced.
    * In all cases it will overwrite the ID value in the entity with the calculated ID.
    */
-  @EntityActionHandler
   createOrReplace(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntityCreateOrReplaceAction<T>
@@ -294,7 +286,6 @@ export abstract class EntityState<T> {
     patchState({ ...updated, lastUpdated: Date.now() });
   }
 
-  @EntityActionHandler
   update(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntityUpdateAction<T>
@@ -325,7 +316,6 @@ export abstract class EntityState<T> {
     patchState({ entities, lastUpdated: Date.now() });
   }
 
-  @EntityActionHandler
   updateActive(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntityUpdateActiveAction<T>
@@ -347,7 +337,6 @@ export abstract class EntityState<T> {
     }
   }
 
-  @EntityActionHandler
   removeActive({ getState, patchState }: StateContext<EntityStateModel<T>>) {
     const { entities, ids, active } = getState();
     delete entities[active];
@@ -359,7 +348,6 @@ export abstract class EntityState<T> {
     });
   }
 
-  @EntityActionHandler
   remove(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntityRemoveAction<T>
@@ -392,12 +380,10 @@ export abstract class EntityState<T> {
     }
   }
 
-  @EntityActionHandler
   reset({ setState }: StateContext<EntityStateModel<T>>) {
     setState(defaultEntityState());
   }
 
-  @EntityActionHandler
   setLoading(
     { patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntitySetLoadingAction
@@ -405,7 +391,6 @@ export abstract class EntityState<T> {
     patchState({ loading: payload });
   }
 
-  @EntityActionHandler
   setActive(
     { patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntitySetActiveAction
@@ -413,12 +398,10 @@ export abstract class EntityState<T> {
     patchState({ active: payload });
   }
 
-  @EntityActionHandler
   clearActive({ patchState }: StateContext<EntityStateModel<T>>) {
     patchState({ active: undefined });
   }
 
-  @EntityActionHandler
   setError(
     { patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntitySetErrorAction
@@ -426,7 +409,6 @@ export abstract class EntityState<T> {
     patchState({ error: payload });
   }
 
-  @EntityActionHandler
   goToPage(
     { getState, patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntityGoToPageAction
@@ -453,7 +435,6 @@ export abstract class EntityState<T> {
     }
   }
 
-  @EntityActionHandler
   setPageSize(
     { patchState }: StateContext<EntityStateModel<T>>,
     { payload }: EntitySetPageSizeAction
@@ -518,14 +499,7 @@ export abstract class EntityState<T> {
   }
 
   private setup(storeClass: Type<EntityState<T>>, actions: string[]) {
-    const baseProto = Reflect.getPrototypeOf(storeClass.prototype);
-
-    // throw error if any action from enum does not have matching handler function
-    const notPresent = actions.find(action => !(action in baseProto));
-    if (notPresent !== undefined) {
-      throw new NoMatchingActionHandlerError(notPresent);
-    }
-
+    // validation if a matching action handler exists has moved to reflection-validation tests
     actions.forEach(fn => {
       const actionName = `[${this.storePath}] ${fn}`;
       storeClass[NGXS_META_KEY].actions[actionName] = [

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -39,15 +39,3 @@ export class UnableToGenerateIdError extends EntityStateError {
     super(`Unable to generate an ID.\n\tCause: ${cause}`);
   }
 }
-
-export class NoMatchingActionHandlerError extends EntityStateError {
-  constructor(action: string) {
-    super(`No matching handler for action '${action}' from EntityActionType enum.`);
-  }
-}
-
-export class NoSuchActionInEnumError extends EntityStateError {
-  constructor(action: string) {
-    super(`No such action '${action}' in EntityActionType enum.`);
-  }
-}

--- a/src/lib/internal.ts
+++ b/src/lib/internal.ts
@@ -1,6 +1,6 @@
 import { EntityState } from './entity-state';
 import { Type } from '@angular/core';
-import { NoActiveEntityError, NoSuchActionInEnumError } from './errors';
+import { NoActiveEntityError } from './errors';
 import { EntityStateModel } from './models';
 
 /**
@@ -57,22 +57,6 @@ export enum EntityActionType {
   Reset = 'reset',
   GoToPage = 'goToPage',
   SetPageSize = 'setPageSize'
-}
-
-const entityActionTypeValues = Object.values(EntityActionType);
-
-/**
- * An optional annotation to verify that the annotated function has a matching action in EntityActionType enum
- * @see EntityActionType
- */
-export function EntityActionHandler(
-  target: Object, // The prototype of the class
-  propertyKey: string, // The name of the method
-  descriptor: TypedPropertyDescriptor<any>
-) {
-  if (!entityActionTypeValues.includes(propertyKey)) {
-    throw new NoSuchActionInEnumError(propertyKey);
-  }
 }
 
 /**


### PR DESCRIPTION
- removed old ToDo comments and clarified behavior where needed
- removed superfluous validation, as they moved to `reflection-validation.spec.ts` in #33
  - validation in `EntityState#setup`
  - validation with the `@EntityActionHandler` annotation