### PR TITLE
refactor: enforce entity type

### DIFF
--- a/integration/app/store/todo/store.ts
+++ b/integration/app/store/todo/store.ts
@@ -20,8 +20,4 @@ export class TodoState extends EntityState<ToDo> {
   constructor() {
     super(TodoState, 'title', IdStrategy.EntityIdGenerator);
   }
-
-  onUpdate(current: Readonly<ToDo>, updated: Partial<ToDo>): ToDo {
-    return { ...current, ...updated };
-  }
 }

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -55,7 +55,7 @@ export function defaultEntityState<T>(
 }
 
 // @dynamic
-export abstract class EntityState<T> {
+export abstract class EntityState<T extends {}> {
   private readonly idKey: string;
   private readonly storePath: string;
   protected readonly idGenerator: IdGenerator<T>;
@@ -79,16 +79,21 @@ export abstract class EntityState<T> {
 
   /**
    * This function is called every time an entity is updated.
-   * It receives the current entity and a partial entity that was either passed directly or generated with a function
+   * It receives the current entity and a partial entity that was either passed directly or generated with a function.
+   * The default implementation uses the spread operator to create a new entity.
+   * You must override this method if your entity type does not support the spread operator.
    * @see Updater
    * @param current The current entity, readonly
    * @param updated The new data as a partial entity
    * @example
-   *onUpdate(current: ToDo, updated: Partial<ToDo>): ToDo {
+   * // default behavior
+   * onUpdate(current: Readonly<T updated: Partial<T>): T {
   return {...current, ...updated};
-}
+ }
    */
-  abstract onUpdate(current: Readonly<T>, updated: Partial<T>): T;
+  onUpdate(current: Readonly<T>, updated: Partial<T>): T {
+    return { ...current, ...updated } as T;
+  }
 
   // ------------------- SELECTORS -------------------
 

--- a/src/tests/entity-state/reflection-validation.spec.ts
+++ b/src/tests/entity-state/reflection-validation.spec.ts
@@ -43,7 +43,7 @@ describe('EntityState reflection validation', () => {
     const protoKeys = Object.keys(Reflect.getPrototypeOf(Reflect.getPrototypeOf(instance)));
     // you have to manually exclude certain methods, which are not action handlers
     // TODO: Add Reflect Meta-data with @EntityActionHandler annotation and query it here?
-    const exclude = ['idOf', 'setup', '_update', '_addOrReplace'];
+    const exclude = ['idOf', 'setup', 'onUpdate', '_update', '_addOrReplace'];
     const actionHandlers = protoKeys.filter(key => !exclude.includes(key));
 
     // actual test


### PR DESCRIPTION
Refactor entity state class to enforce `<T extends {}>`. The behaviour was enforced implicitly so far anyways, as all methods accessed the ID property via `entity[idKey]`.
With this change the `onUpdate` method moved to the abstract class, as the spread operator should work in most cases. If not you can override the implemtation in your individual state class.

>Closes issue #8 .