### PR TITLE
refactor: state operators

### DIFF
--- a/src/lib/actions/type-alias.ts
+++ b/src/lib/actions/type-alias.ts
@@ -5,7 +5,7 @@
  * - a function that returns true for entities to be selected
  * - null to select all entities
  */
-export type EntitySelector<T> = string | string[] | ((T) => boolean) | null;
+export type EntitySelector<T> = string | string[] | ((entity: T) => boolean) | null;
 
 /**
  * An Updater will be applied to the current entity, before onUpdate is run with its result.

--- a/src/lib/actions/update.ts
+++ b/src/lib/actions/update.ts
@@ -4,7 +4,7 @@ import { EntityState } from '../entity-state';
 import { Type } from '@angular/core';
 
 export interface EntityUpdate<T> {
-  id: EntitySelector<T>;
+  selector: EntitySelector<T>;
   data: Updater<T>;
 }
 
@@ -17,12 +17,15 @@ export class Update<T> {
    * Generates an action that will update the current active entity.
    * If no entity is active a runtime error will be thrown.
    * @param target The targeted state class
-   * @param id An EntitySelector that determines the entities to update
+   * @param selector An EntitySelector that determines the entities to update
    * @param data An Updater that will be applied to the selected entities
    * @see EntitySelector
    * @see Updater
    */
-  constructor(target: Type<EntityState<T>>, id: EntitySelector<T>, data: Updater<T>) {
-    return generateActionObject(EntityActionType.Update, target, { id, data });
+  constructor(target: Type<EntityState<T>>, selector: EntitySelector<T>, data: Updater<T>) {
+    return generateActionObject(EntityActionType.Update, target, {
+      selector,
+      data
+    } as EntityUpdate<T>);
   }
 }

--- a/src/lib/actions/update.ts
+++ b/src/lib/actions/update.ts
@@ -3,11 +3,13 @@ import { EntityActionType, EntitySelector, Updater } from './type-alias';
 import { EntityState } from '../entity-state';
 import { Type } from '@angular/core';
 
+export interface EntityUpdate<T> {
+  id: EntitySelector<T>;
+  data: Updater<T>;
+}
+
 export interface EntityUpdateAction<T> {
-  payload: {
-    id: EntitySelector<T>;
-    data: Updater<T>;
-  };
+  payload: EntityUpdate<T>;
 }
 
 export class Update<T> {

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -19,7 +19,7 @@ import {
   asArray,
   elvis,
   getActive,
-  HashMap,
+  Dictionary,
   mustGetActive,
   NGXS_META_KEY,
   wrapOrClamp
@@ -167,7 +167,7 @@ export abstract class EntityState<T extends {}> {
   /**
    * Returns a selector for the map of entities
    */
-  static get entitiesMap(): StateSelector<HashMap<any>> {
+  static get entitiesMap(): StateSelector<Dictionary<any>> {
     const that = this;
     return state => {
       const subState = elvis(state, that.staticStorePath) as EntityStateModel<any>;
@@ -453,7 +453,7 @@ export abstract class EntityState<T extends {}> {
     state: EntityStateModel<T>,
     payload: T | T[],
     generateId: (payload: Partial<T>, state: EntityStateModel<T>) => string
-  ): { entities: HashMap<T>; ids: string[] } {
+  ): { entities: Dictionary<T>; ids: string[] } {
     const entities = { ...state.entities };
     const ids = [...state.ids];
 
@@ -485,10 +485,10 @@ export abstract class EntityState<T extends {}> {
    * @param id The ID to find the current entity in the map
    */
   private _update(
-    entities: HashMap<T>,
+    entities: Dictionary<T>,
     entity: Partial<T>,
     id: string = this.idOf(entity)
-  ): HashMap<T> {
+  ): Dictionary<T> {
     if (id === undefined) {
       throw new UpdateFailedError(new InvalidIdError(id));
     }

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -26,7 +26,7 @@ import {
 } from './internal';
 import { EntityStateModel, StateSelector } from './models';
 import IdGenerator = IdStrategy.IdGenerator;
-import { removeAllEntities, removeEntities } from './state-operators';
+import { removeAllEntities, removeEntities } from './state-operators/removal';
 
 /**
  * Returns a new object which serves as the default state.

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -26,7 +26,7 @@ import {
 } from './internal';
 import { EntityStateModel, StateSelector } from './models';
 import IdGenerator = IdStrategy.IdGenerator;
-import { removeAllEntities, removeEntities } from '@ngxs-labs/entity-state';
+import { removeAllEntities, removeEntities } from './state-operators';
 
 /**
  * Returns a new object which serves as the default state.

--- a/src/lib/entity-state.ts
+++ b/src/lib/entity-state.ts
@@ -261,7 +261,9 @@ export abstract class EntityState<T extends {}> {
    */
   add({ setState }: StateContext<EntityStateModel<T>>, { payload }: EntityAddAction<T>) {
     setState(
-      addOrReplace(payload, this.idKey, (p, state) => this.idGenerator.generateId(p, state))
+      addOrReplace(payload, this.idKey, (entity, state) =>
+        this.idGenerator.generateId(entity, state)
+      )
     );
   }
 
@@ -276,8 +278,8 @@ export abstract class EntityState<T extends {}> {
     { payload }: EntityCreateOrReplaceAction<T>
   ) {
     setState(
-      addOrReplace(payload, this.idKey, (p, state) =>
-        this.idGenerator.getPresentIdOrGenerate(p, state)
+      addOrReplace(payload, this.idKey, (entity, state) =>
+        this.idGenerator.getPresentIdOrGenerate(entity, state)
       )
     );
   }
@@ -312,8 +314,8 @@ export abstract class EntityState<T extends {}> {
       const deleteIds: string[] =
         typeof payload === 'function'
           ? Object.values(getState().entities)
-              .filter(e => payload(e))
-              .map(e => this.idOf(e))
+              .filter(entity => payload(entity))
+              .map(entity => this.idOf(entity))
           : asArray(payload);
       // can't pass in predicate as you need IDs and thus EntityState#idOf
       setState(removeEntities(deleteIds));

--- a/src/lib/internal.ts
+++ b/src/lib/internal.ts
@@ -4,11 +4,20 @@ import { NoActiveEntityError } from './errors';
 import { EntityStateModel } from './models';
 
 /**
- * type alias for javascript object literal
+ * Type alias for an object literal.
+ * Only allows strings as keys.
  */
-export interface HashMap<T> {
-  [id: string]: T;
+export interface Dictionary<T> {
+  [key: string]: T;
 }
+
+/**
+ * Type alias for an object literal.
+ * Only allows strings as keys.
+ * @deprecated Use Dictionary type instead
+ * @see Dictionary
+ */
+export type HashMap<T> = Dictionary<T>;
 
 export const NGXS_META_KEY = 'NGXS_META';
 

--- a/src/lib/internal.ts
+++ b/src/lib/internal.ts
@@ -11,14 +11,6 @@ export interface Dictionary<T> {
   [key: string]: T;
 }
 
-/**
- * Type alias for an object literal.
- * Only allows strings as keys.
- * @deprecated Use Dictionary type instead
- * @see Dictionary
- */
-export type HashMap<T> = Dictionary<T>;
-
 export const NGXS_META_KEY = 'NGXS_META';
 
 /**

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -16,3 +16,16 @@ export interface EntityStateModel<T> {
 }
 
 export type StateSelector<T> = (state: EntityStateModel<any>) => T;
+
+export type DeepReadonly<T> = T extends (infer R)[]
+  ? DeepReadonlyArray<R>
+  : T extends Function
+  ? T
+  : T extends object
+  ? DeepReadonlyObject<T>
+  : T;
+
+// This should be ReadonlyArray but it has implications.
+export interface DeepReadonlyArray<T> extends Array<DeepReadonly<T>> {}
+
+export type DeepReadonlyObject<T> = { readonly [P in keyof T]: DeepReadonly<T[P]> };

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -29,3 +29,8 @@ export type DeepReadonly<T> = T extends (infer R)[]
 export interface DeepReadonlyArray<T> extends Array<DeepReadonly<T>> {}
 
 export type DeepReadonlyObject<T> = { readonly [P in keyof T]: DeepReadonly<T[P]> };
+
+/**
+ * Function that provides an ID for the given entity
+ */
+export type IdProvider<T> = (entity: Partial<T>, state: EntityStateModel<T>) => string;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,11 +1,11 @@
-import { HashMap } from './internal';
+import { Dictionary } from './internal';
 
 /**
  * Interface for an EntityState.
  * Includes the entities in an object literal, the loading and error state and the ID of the active selected entity.
  */
 export interface EntityStateModel<T> {
-  entities: HashMap<T>;
+  entities: Dictionary<T>;
   loading: boolean;
   error: Error | undefined;
   active: string | undefined;

--- a/src/lib/state-operators/adding.ts
+++ b/src/lib/state-operators/adding.ts
@@ -1,0 +1,45 @@
+import { StateOperator } from '@ngxs/store';
+import { asArray } from '../internal';
+import { EntityStateModel, IdProvider } from '../models';
+
+/**
+ * Adds or replaces the given entities to the state.
+ * For each entity an ID will be calculated, based on the given provider.
+ * This operator ensures that the calculated ID is added to the entity, at the specified id-field.
+ * The `lastUpdated` timestamp will be updated.
+ * @param entities the new entities to add or replace
+ * @param idKey key of the id-field of an entity
+ * @param idProvider function to provide an ID for the given entity
+ */
+export function addOrReplace<T>(
+  entities: T | T[],
+  idKey: string,
+  idProvider: IdProvider<T>
+): StateOperator<EntityStateModel<T>> {
+  return (state: EntityStateModel<T>) => {
+    const nextEntities = { ...state.entities };
+    const nextIds = [...state.ids];
+    let nextState = state; // will be reassigned while looping over new entities
+
+    asArray(entities).forEach(entity => {
+      const id = idProvider(entity, nextState);
+      entity[idKey] = id; // ensure ID is in the entity
+      nextEntities[id] = entity;
+      if (!nextIds.includes(id)) {
+        nextIds.push(id);
+      }
+      nextState = {
+        ...nextState,
+        entities: nextEntities,
+        ids: nextIds
+      };
+    });
+
+    return {
+      ...nextState,
+      entities: nextEntities,
+      ids: nextIds,
+      lastUpdated: Date.now()
+    };
+  };
+}

--- a/src/lib/state-operators/adding.ts
+++ b/src/lib/state-operators/adding.ts
@@ -23,8 +23,12 @@ export function addOrReplace<T>(
 
     asArray(entities).forEach(entity => {
       const id = idProvider(entity, nextState);
-      entity[idKey] = id; // ensure ID is in the entity
-      nextEntities[id] = entity;
+      let updatedEntity = entity;
+      if (entity[idKey] !== id) {
+        // ensure ID is in the entity
+        updatedEntity = { ...entity, [idKey]: id };
+      }
+      nextEntities[id] = updatedEntity;
       if (!nextIds.includes(id)) {
         nextIds.push(id);
       }

--- a/src/lib/state-operators/index.ts
+++ b/src/lib/state-operators/index.ts
@@ -1,2 +1,4 @@
+export * from './adding';
 export * from './removal';
 export * from './timestamp';
+export * from './updating';

--- a/src/lib/state-operators/index.ts
+++ b/src/lib/state-operators/index.ts
@@ -1,0 +1,2 @@
+export * from './removal';
+export * from './timestamp';

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -33,7 +33,7 @@ export function removeEntities<T>(ids: string[]): StateOperator<EntityStateModel
   });
   return compose(
     entityRemoval,
-    clearActiveOnRemoval(ids),
+    clearActiveIfRemoved(ids),
     updateTimestamp()
   );
 }
@@ -43,7 +43,7 @@ export function removeEntities<T>(ids: string[]): StateOperator<EntityStateModel
  * All other fields will remain untouched in any case.
  * @param idsForRemoval the IDs to be removed
  */
-export function clearActiveOnRemoval<T>(
+export function clearActiveIfRemoved<T>(
   idsForRemoval: string[]
 ): StateOperator<EntityStateModel<T>> {
   return (state: EntityStateModel<any>) => {

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -1,0 +1,63 @@
+import { EntityStateModel } from '../models';
+import { compose, patch } from '@ngxs/store/operators';
+import { HashMap } from '../internal';
+import { StateOperator } from '@ngxs/store';
+import { Predicate } from '@ngxs/store/operators/internals';
+import { updateTimestamp } from '@ngxs-labs/entity-state';
+
+export function removeAllEntities<T>(): StateOperator<EntityStateModel<T>> {
+  return (state: EntityStateModel<T>) => {
+    return {
+      ...state,
+      entities: {},
+      ids: [],
+      active: undefined,
+      lastUpdated: Date.now()
+    };
+  };
+}
+
+export function removeEntities<T>(ids: string[]): StateOperator<EntityStateModel<T>> {
+  const entityRemoval = patch<EntityStateModel<any>>({
+    entities: removeEntitiesFromMap(ids),
+    ids: removeEntitiesFromArray(ids)
+  });
+  return compose(
+    entityRemoval,
+    clearActiveOnRemoval(ids),
+    updateTimestamp()
+  );
+}
+
+export function clearActiveOnRemoval<T>(
+  forRemoval: string[]
+): StateOperator<EntityStateModel<T>> {
+  return (state: EntityStateModel<any>) => {
+    return {
+      ...state,
+      active: forRemoval.includes(state.active) ? undefined : state.active
+    };
+  };
+}
+
+export function removeEntitiesFromArray<T>(forRemoval: T[]): StateOperator<Array<T>> {
+  return (existing: ReadonlyArray<T>) => {
+    return existing.filter(v => !forRemoval.includes(v));
+  };
+}
+
+export function removeEntitiesByPredicate<T>(
+  predicate: Predicate<T>
+): StateOperator<Array<T>> {
+  return (existing: ReadonlyArray<T>) => {
+    return existing.filter(v => predicate(v));
+  };
+}
+
+export function removeEntitiesFromMap<T>(selector: string[]): StateOperator<HashMap<T>> {
+  return (existing: Readonly<HashMap<T>>): HashMap<T> => {
+    const clone = { ...existing };
+    selector.forEach(s => delete clone[s]);
+    return clone;
+  };
+}

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -65,18 +65,6 @@ export function removeEntitiesFromArray<T>(forRemoval: T[]): StateOperator<Array
 }
 
 /**
- * Removes all items from the existing items that match the given predicate.
- * @param predicate predicate to determine if item should be removed
- */
-export function removeEntitiesByPredicate<T>(
-  predicate: Predicate<T>
-): StateOperator<Array<T>> {
-  return (existing: ReadonlyArray<T>) => {
-    return existing.filter(value => predicate(value));
-  };
-}
-
-/**
  * Removes items from the dictionary, based on the given keys.
  * @param keysForRemoval the keys to be removed
  */

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -1,6 +1,6 @@
 import { EntityStateModel } from '../models';
 import { compose, patch } from '@ngxs/store/operators';
-import { HashMap } from '../internal';
+import { Dictionary } from '../internal';
 import { StateOperator } from '@ngxs/store';
 import { Predicate } from '@ngxs/store/operators/internals';
 import { updateTimestamp } from '@ngxs-labs/entity-state';
@@ -28,7 +28,7 @@ export function removeAllEntities<T>(): StateOperator<EntityStateModel<T>> {
  */
 export function removeEntities<T>(ids: string[]): StateOperator<EntityStateModel<T>> {
   const entityRemoval = patch<EntityStateModel<any>>({
-    entities: removeEntitiesFromMap(ids),
+    entities: removeEntitiesFromDictionary(ids),
     ids: removeEntitiesFromArray(ids)
   });
   return compose(
@@ -77,11 +77,13 @@ export function removeEntitiesByPredicate<T>(
 }
 
 /**
- * Removes items from the map, based on the given keys.
+ * Removes items from the dictionary, based on the given keys.
  * @param keysForRemoval the keys to be removed
  */
-export function removeEntitiesFromMap<T>(keysForRemoval: string[]): StateOperator<HashMap<T>> {
-  return (existing: Readonly<HashMap<T>>): HashMap<T> => {
+export function removeEntitiesFromDictionary<T>(
+  keysForRemoval: string[]
+): StateOperator<Dictionary<T>> {
+  return (existing: Readonly<Dictionary<T>>): Dictionary<T> => {
     const clone = { ...existing };
     keysForRemoval.forEach(s => delete clone[s]);
     return clone;

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -1,9 +1,9 @@
-import { EntityStateModel } from '../models';
-import { compose, patch } from '@ngxs/store/operators';
-import { Dictionary } from '../internal';
 import { StateOperator } from '@ngxs/store';
+import { compose, patch } from '@ngxs/store/operators';
 import { Predicate } from '@ngxs/store/operators/internals';
-import { updateTimestamp } from '@ngxs-labs/entity-state';
+import { Dictionary } from '../internal';
+import { EntityStateModel } from '../models';
+import { updateTimestamp } from './timestamp';
 
 /**
  * Removes all entities, clears the active entity and updates the `lastUpdated` timestamp.

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -5,6 +5,9 @@ import { StateOperator } from '@ngxs/store';
 import { Predicate } from '@ngxs/store/operators/internals';
 import { updateTimestamp } from '@ngxs-labs/entity-state';
 
+/**
+ * Removes all entities, clears the active entity and updates the `lastUpdated` timestamp.
+ */
 export function removeAllEntities<T>(): StateOperator<EntityStateModel<T>> {
   return (state: EntityStateModel<T>) => {
     return {
@@ -17,6 +20,12 @@ export function removeAllEntities<T>(): StateOperator<EntityStateModel<T>> {
   };
 }
 
+/**
+ * Removes the entities specified by the given IDs.
+ * The active entity will be cleared if included in the given IDs.
+ * Updates the `lastUpdated` timestamp.
+ * @param ids IDs to remove
+ */
 export function removeEntities<T>(ids: string[]): StateOperator<EntityStateModel<T>> {
   const entityRemoval = patch<EntityStateModel<any>>({
     entities: removeEntitiesFromMap(ids),
@@ -29,23 +38,36 @@ export function removeEntities<T>(ids: string[]): StateOperator<EntityStateModel
   );
 }
 
+/**
+ * Only clears the `active` entity, if it's included in the given array.
+ * All other fields will remain untouched in any case.
+ * @param idsForRemoval the IDs to be removed
+ */
 export function clearActiveOnRemoval<T>(
-  forRemoval: string[]
+  idsForRemoval: string[]
 ): StateOperator<EntityStateModel<T>> {
   return (state: EntityStateModel<any>) => {
     return {
       ...state,
-      active: forRemoval.includes(state.active) ? undefined : state.active
+      active: idsForRemoval.includes(state.active) ? undefined : state.active
     };
   };
 }
 
+/**
+ * Removes the given items from the existing items, based on equality.
+ * @param forRemoval items to remove
+ */
 export function removeEntitiesFromArray<T>(forRemoval: T[]): StateOperator<Array<T>> {
   return (existing: ReadonlyArray<T>) => {
     return existing.filter(v => !forRemoval.includes(v));
   };
 }
 
+/**
+ * Removes all items from the existing items that match the given predicate.
+ * @param predicate predicate to determine if item should be removed
+ */
 export function removeEntitiesByPredicate<T>(
   predicate: Predicate<T>
 ): StateOperator<Array<T>> {
@@ -54,10 +76,14 @@ export function removeEntitiesByPredicate<T>(
   };
 }
 
-export function removeEntitiesFromMap<T>(selector: string[]): StateOperator<HashMap<T>> {
+/**
+ * Removes items from the map, based on the given keys.
+ * @param keysForRemoval the keys to be removed
+ */
+export function removeEntitiesFromMap<T>(keysForRemoval: string[]): StateOperator<HashMap<T>> {
   return (existing: Readonly<HashMap<T>>): HashMap<T> => {
     const clone = { ...existing };
-    selector.forEach(s => delete clone[s]);
+    keysForRemoval.forEach(s => delete clone[s]);
     return clone;
   };
 }

--- a/src/lib/state-operators/removal.ts
+++ b/src/lib/state-operators/removal.ts
@@ -60,7 +60,7 @@ export function clearActiveOnRemoval<T>(
  */
 export function removeEntitiesFromArray<T>(forRemoval: T[]): StateOperator<Array<T>> {
   return (existing: ReadonlyArray<T>) => {
-    return existing.filter(v => !forRemoval.includes(v));
+    return existing.filter(value => !forRemoval.includes(value));
   };
 }
 
@@ -72,7 +72,7 @@ export function removeEntitiesByPredicate<T>(
   predicate: Predicate<T>
 ): StateOperator<Array<T>> {
   return (existing: ReadonlyArray<T>) => {
-    return existing.filter(v => predicate(v));
+    return existing.filter(value => predicate(value));
   };
 }
 
@@ -85,7 +85,7 @@ export function removeEntitiesFromDictionary<T>(
 ): StateOperator<Dictionary<T>> {
   return (existing: Readonly<Dictionary<T>>): Dictionary<T> => {
     const clone = { ...existing };
-    keysForRemoval.forEach(s => delete clone[s]);
+    keysForRemoval.forEach(key => delete clone[key]);
     return clone;
   };
 }

--- a/src/lib/state-operators/timestamp.ts
+++ b/src/lib/state-operators/timestamp.ts
@@ -1,0 +1,18 @@
+import { StateOperator } from '@ngxs/store';
+import { EntityStateModel } from '@ngxs-labs/entity-state';
+import { compose, patch } from '@ngxs/store/operators';
+
+export function updateTimestamp(): StateOperator<EntityStateModel<any>> {
+  return patch<EntityStateModel<any>>({
+    lastUpdated: Date.now()
+  });
+}
+
+export function alsoUpdateTimestamp(
+  operator: StateOperator<EntityStateModel<any>>
+): StateOperator<EntityStateModel<any>> {
+  return compose(
+    updateTimestamp(),
+    operator
+  );
+}

--- a/src/lib/state-operators/timestamp.ts
+++ b/src/lib/state-operators/timestamp.ts
@@ -1,5 +1,5 @@
 import { StateOperator } from '@ngxs/store';
-import { EntityStateModel } from '@ngxs-labs/entity-state';
+import { EntityStateModel } from '../models';
 import { compose, patch } from '@ngxs/store/operators';
 
 export function updateTimestamp(): StateOperator<EntityStateModel<any>> {

--- a/src/lib/state-operators/updating.ts
+++ b/src/lib/state-operators/updating.ts
@@ -21,7 +21,7 @@ export function update<T>(
   return (state: EntityStateModel<T>) => {
     let entities = { ...state.entities }; // create copy
 
-    const affected = getAffectedValues(Object.values(entities), payload.id, idKey);
+    const affected = getAffectedValues(Object.values(entities), payload.selector, idKey);
 
     if (typeof payload.data === 'function') {
       affected.forEach(entity => {

--- a/src/lib/state-operators/updating.ts
+++ b/src/lib/state-operators/updating.ts
@@ -1,0 +1,91 @@
+import { StateOperator } from '@ngxs/store';
+import { asArray, Dictionary, mustGetActive } from '../internal';
+import { EntityStateModel } from '../models';
+import { EntitySelector, EntityUpdate, Updater } from '../actions';
+import { InvalidIdError, NoSuchEntityError, UpdateFailedError } from '../errors';
+
+export type OnUpdate<T> = (current: Readonly<T>, updated: Partial<T>) => T;
+
+/**
+ * Updates the given entities in the state.
+ * Entities will be merged with the given `onUpdate` function.
+ * @param payload the updated entities
+ * @param idKey key of the id-field of an entity
+ * @param onUpdate update function to call on each entity
+ */
+export function update<T>(
+  payload: EntityUpdate<T>,
+  idKey: string,
+  onUpdate: OnUpdate<T>
+): StateOperator<EntityStateModel<T>> {
+  return (state: EntityStateModel<T>) => {
+    let entities = { ...state.entities }; // create copy
+
+    const affected = getAffectedValues(Object.values(entities), payload.id, idKey);
+
+    if (typeof payload.data === 'function') {
+      affected.forEach(e => {
+        entities = updateDictionary(entities, (<Function>payload.data)(e), e[idKey], onUpdate);
+      });
+    } else {
+      affected.forEach(e => {
+        entities = updateDictionary(entities, payload.data as Partial<T>, e[idKey], onUpdate);
+      });
+    }
+
+    return {
+      ...state,
+      entities,
+      lastUpdated: Date.now()
+    };
+  };
+}
+
+export function updateActive<T>(payload: Updater<T>, idKey: string, onUpdate: OnUpdate<T>) {
+  return (state: EntityStateModel<T>) => {
+    const { id: activeId, active } = mustGetActive(state);
+    const { entities } = state;
+
+    if (typeof payload === 'function') {
+      return {
+        ...state,
+        entities: updateDictionary(entities, payload(active), activeId, onUpdate),
+        lastUpdated: Date.now()
+      };
+    } else {
+      return {
+        ...state,
+        entities: updateDictionary(entities, payload, activeId, onUpdate),
+        lastUpdated: Date.now()
+      };
+    }
+  };
+}
+
+export function updateDictionary<T>(
+  entities: Dictionary<T>,
+  entity: Partial<T>,
+  id: string,
+  onUpdate: OnUpdate<T>
+): Dictionary<T> {
+  if (id === undefined) {
+    throw new UpdateFailedError(new InvalidIdError(id));
+  }
+  const current = entities[id];
+  if (current === undefined) {
+    throw new UpdateFailedError(new NoSuchEntityError(id));
+  }
+  const updated = onUpdate(current, entity);
+  return { ...entities, [id]: updated };
+}
+
+function getAffectedValues<T>(entities: T[], selector: EntitySelector<T>, idKey: string): T[] {
+  if (selector === null) {
+    return entities;
+  } else if (typeof selector === 'function') {
+    return entities.filter(e => (<Function>selector)(e));
+  } else {
+    const ids = asArray(selector);
+    return entities.filter(e => ids.includes(e[idKey]));
+  }
+}

--- a/src/lib/state-operators/updating.ts
+++ b/src/lib/state-operators/updating.ts
@@ -24,12 +24,22 @@ export function update<T>(
     const affected = getAffectedValues(Object.values(entities), payload.id, idKey);
 
     if (typeof payload.data === 'function') {
-      affected.forEach(e => {
-        entities = updateDictionary(entities, (<Function>payload.data)(e), e[idKey], onUpdate);
+      affected.forEach(entity => {
+        entities = updateDictionary(
+          entities,
+          (<Function>payload.data)(entity),
+          entity[idKey],
+          onUpdate
+        );
       });
     } else {
-      affected.forEach(e => {
-        entities = updateDictionary(entities, payload.data as Partial<T>, e[idKey], onUpdate);
+      affected.forEach(entity => {
+        entities = updateDictionary(
+          entities,
+          payload.data as Partial<T>,
+          entity[idKey],
+          onUpdate
+        );
       });
     }
 
@@ -83,9 +93,9 @@ function getAffectedValues<T>(entities: T[], selector: EntitySelector<T>, idKey:
   if (selector === null) {
     return entities;
   } else if (typeof selector === 'function') {
-    return entities.filter(e => (<Function>selector)(e));
+    return entities.filter(entity => (<Function>selector)(entity));
   } else {
     const ids = asArray(selector);
-    return entities.filter(e => ids.includes(e[idKey]));
+    return entities.filter(entity => ids.includes(entity[idKey]));
   }
 }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -4,3 +4,4 @@ export * from './lib/errors';
 export * from './lib/id-strategy';
 export * from './lib/models';
 export * from './lib/action-handlers';
+export * from './lib/state-operators';

--- a/src/tests/entity-state/action-handlers.spec.ts
+++ b/src/tests/entity-state/action-handlers.spec.ts
@@ -63,7 +63,8 @@ describe('EntityState action handlers', () => {
 
   describe('add', () => {
     it('should add an entity', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.entities).toEqual({
           a: { title: 'a' },
           b: { title: 'b' },
@@ -76,9 +77,12 @@ describe('EntityState action handlers', () => {
     });
 
     it('should throw an error for existing IDs', () => {
-      const context = mockStateContext();
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
+      });
       try {
         stateInstance.add(context, { payload: { title: 'a' } });
+        fail('Action should throw an error');
       } catch (e) {
         expect(e.message).toBe(
           new UnableToGenerateIdError('The provided ID already exists: a').message
@@ -87,7 +91,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should update lastUpdated', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
       });
       stateInstance.add(context, { payload: { title: 'd' } });
@@ -96,7 +101,8 @@ describe('EntityState action handlers', () => {
 
   describe('createOrReplace', () => {
     it('should add a new entity for a new ID', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.entities).toEqual({
           a: { title: 'a' },
           b: { title: 'b' },
@@ -109,7 +115,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should replace an entity for an existing ID', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.entities).toEqual({
           a: { title: 'a' },
           b: { title: 'b' },
@@ -122,7 +129,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should update lastUpdated', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
       });
       stateInstance.createOrReplace(context, { payload: { title: 'd' } });

--- a/src/tests/entity-state/action-handlers.spec.ts
+++ b/src/tests/entity-state/action-handlers.spec.ts
@@ -143,7 +143,8 @@ describe('EntityState action handlers', () => {
 
     describe('partial entity updates', () => {
       it('should update by single ID', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b' },
@@ -160,7 +161,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update by multiple IDs', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           console.log('val.entities:', val.entities);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
@@ -178,7 +180,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update by predicate', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b', test: 42 },
@@ -195,7 +198,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update all with null', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b', test: 42 },
@@ -212,7 +216,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update lastUpdated', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
         });
 
@@ -227,7 +232,8 @@ describe('EntityState action handlers', () => {
 
     describe('function updates', () => {
       it('should update by single ID', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b' },
@@ -244,8 +250,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update by multiple IDs', () => {
-        const context = mockStateContext(val => {
-          console.log('val.entities:', val.entities);
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b', test: 42 },
@@ -262,7 +268,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update by predicate', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b', test: 42 },
@@ -279,7 +286,8 @@ describe('EntityState action handlers', () => {
       });
 
       it('should update all with null', () => {
-        const context = mockStateContext(val => {
+        const context = mockStateContext(undefined, (op: any) => {
+          const val = op(state.todo);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b', test: 42 },
@@ -301,7 +309,8 @@ describe('EntityState action handlers', () => {
     // updateActive works with Updater<T> = Partial<T> | ((entity: Readonly<T>) => Partial<T>);
 
     it('should update the active entity by partial entity', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.entities).toEqual({
           a: { title: 'a', test: 42 },
           b: { title: 'b' },
@@ -312,7 +321,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should update the active entity by update fn', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.entities).toEqual({
           a: { title: 'a', test: 42 },
           b: { title: 'b' },
@@ -323,7 +333,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should update lastUpdated', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
       });
 

--- a/src/tests/entity-state/action-handlers.spec.ts
+++ b/src/tests/entity-state/action-handlers.spec.ts
@@ -154,7 +154,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: 'a',
+            selector: 'a',
             data: { test: 42 }
           }
         });
@@ -173,7 +173,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: ['a', 'b'],
+            selector: ['a', 'b'],
             data: { test: 42 }
           }
         });
@@ -191,7 +191,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: entity => entity.title !== 'c',
+            selector: entity => entity.title !== 'c',
             data: { test: 42 }
           }
         });
@@ -209,7 +209,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: null,
+            selector: null,
             data: { test: 42 }
           }
         });
@@ -223,7 +223,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: null,
+            selector: null,
             data: { test: 42 }
           }
         });
@@ -243,7 +243,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: 'a',
+            selector: 'a',
             data: () => ({ test: 42 })
           }
         });
@@ -261,7 +261,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: ['a', 'b'],
+            selector: ['a', 'b'],
             data: () => ({ test: 42 })
           }
         });
@@ -279,7 +279,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: entity => entity.title !== 'c',
+            selector: entity => entity.title !== 'c',
             data: () => ({ test: 42 })
           }
         });
@@ -297,7 +297,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            id: null,
+            selector: null,
             data: () => ({ test: 42 })
           }
         });

--- a/src/tests/entity-state/action-handlers.spec.ts
+++ b/src/tests/entity-state/action-handlers.spec.ts
@@ -326,7 +326,8 @@ describe('EntityState action handlers', () => {
   describe('removeActive', () => {
     it('should remove the active entity', () => {
       expect(state.todo.active).toBe('a'); // verify test data
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.active).toBeUndefined();
         expect(val.entities).toEqual({
           b: { title: 'b' },
@@ -338,7 +339,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should update lastUpdated', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
       });
 
@@ -350,7 +352,8 @@ describe('EntityState action handlers', () => {
     // remove works with EntitySelector<T> = string | string[] | ((T) => boolean) | null;
 
     it('should remove by single ID', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.active).toBeUndefined();
         expect(val.entities).toEqual({
           b: { title: 'b' },
@@ -362,7 +365,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should remove by multiple IDs', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.active).toBeUndefined();
         expect(val.entities).toEqual({
           b: { title: 'b' }
@@ -373,7 +377,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should remove by predicate', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.active).toBeUndefined();
         expect(val.entities).toEqual({
           b: { title: 'b' }
@@ -384,7 +389,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should remove all with null', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.active).toBeUndefined();
         expect(val.entities).toEqual({});
         expect(val.ids).toEqual([]);
@@ -393,7 +399,8 @@ describe('EntityState action handlers', () => {
     });
 
     it('should update lastUpdated', () => {
-      const context = mockStateContext(val => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
         expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
       });
 

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -12,6 +12,11 @@
       "element",
       "entity",
       "kebab-case"
+    ],
+    "import-blacklist": [
+      true,
+      "entity-state",
+      "@ngxs-labs/entity-state"
     ]
   }
 }


### PR DESCRIPTION
Migrate `EntityState` methods to use state operators.

---

Closes #81 