### PR TITLE
refactor: add RemoveAll and UpdateAll actions

### DIFF
--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -13,7 +13,9 @@ import {
   SetLoading,
   SetPageSize,
   Update,
-  UpdateActive
+  UpdateActive,
+  RemoveAll,
+  UpdateAll
 } from '@ngxs-labs/entity-state';
 import { Observable } from 'rxjs';
 import { ToDo, TodoState } from './store/todo';
@@ -117,7 +119,7 @@ export class AppComponent {
   }
 
   clearEntities() {
-    this.store.dispatch(new Remove(TodoState, null));
+    this.store.dispatch(new RemoveAll(TodoState));
   }
 
   addToDo() {
@@ -131,13 +133,7 @@ export class AppComponent {
   }
 
   doneAll() {
-    this.store.dispatch(
-      new Update(
-        TodoState,
-        null, // select all
-        { done: true }
-      )
-    );
+    this.store.dispatch(new UpdateAll(TodoState, { done: true }));
   }
 
   // --------- for tests ---------

--- a/src/lib/actions/remove.ts
+++ b/src/lib/actions/remove.ts
@@ -8,12 +8,22 @@ export type EntityRemoveAction<T> = Payload<EntitySelector<T>>;
 export class Remove<T> {
   /**
    * Generates an action that will remove the given entities from the state.
-   * Put null if all entities should be removed.
    * @param target The targeted state class
    * @param payload An EntitySelector payload
    * @see EntitySelector
+   * @see RemoveAll
    */
   constructor(target: Type<EntityState<T>>, payload: EntitySelector<T>) {
     return generateActionObject(EntityActionType.Remove, target, payload);
+  }
+}
+
+export class RemoveAll {
+  /**
+   * Generates an action that will remove all entities from the state.
+   * @param target The targeted state class
+   */
+  constructor(target: Type<EntityState<any>>) {
+    return generateActionObject(EntityActionType.RemoveAll, target);
   }
 }

--- a/src/lib/actions/type-alias.ts
+++ b/src/lib/actions/type-alias.ts
@@ -1,11 +1,11 @@
 /**
  * An EntitySelector determines which entities will be affected.
  * Can be one of the following:
- * - one or multiple IDs in form of a string or an array of strings
- * - a function that returns true for entities to be selected
- * - null to select all entities
+ * - a single ID in form of a string
+ * - multiple IDs in form of an array of strings
+ * - a predicate function that returns `true` for entities to be selected
  */
-export type EntitySelector<T> = string | string[] | ((entity: T) => boolean) | null;
+export type EntitySelector<T> = string | string[] | ((entity: T) => boolean);
 
 /**
  * An Updater will be applied to the current entity, before onUpdate is run with its result.
@@ -30,8 +30,10 @@ export enum EntityActionType {
   Add = 'add',
   CreateOrReplace = 'createOrReplace',
   Update = 'update',
+  UpdateAll = 'updateAll',
   UpdateActive = 'updateActive',
   Remove = 'remove',
+  RemoveAll = 'removeAll',
   RemoveActive = 'removeActive',
   SetLoading = 'setLoading',
   SetError = 'setError',

--- a/src/lib/actions/update.ts
+++ b/src/lib/actions/update.ts
@@ -4,7 +4,7 @@ import { EntityState } from '../entity-state';
 import { Type } from '@angular/core';
 
 export interface EntityUpdate<T> {
-  selector: EntitySelector<T>;
+  selector?: EntitySelector<T>;
   data: Updater<T>;
 }
 
@@ -14,8 +14,7 @@ export interface EntityUpdateAction<T> {
 
 export class Update<T> {
   /**
-   * Generates an action that will update the current active entity.
-   * If no entity is active a runtime error will be thrown.
+   * Generates an action that will update all entities, specified by the given selector.
    * @param target The targeted state class
    * @param selector An EntitySelector that determines the entities to update
    * @param data An Updater that will be applied to the selected entities
@@ -25,6 +24,22 @@ export class Update<T> {
   constructor(target: Type<EntityState<T>>, selector: EntitySelector<T>, data: Updater<T>) {
     return generateActionObject(EntityActionType.Update, target, {
       selector,
+      data
+    } as EntityUpdate<T>);
+  }
+}
+
+export class UpdateAll<T> {
+  /**
+   * Generates an action that will update all entities.
+   * If no entity is active a runtime error will be thrown.
+   * @param target The targeted state class
+   * @param data An Updater that will be applied to all entities
+   * @see EntitySelector
+   * @see Updater
+   */
+  constructor(target: Type<EntityState<T>>, data: Updater<T>) {
+    return generateActionObject(EntityActionType.UpdateAll, target, {
       data
     } as EntityUpdate<T>);
   }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -39,3 +39,9 @@ export class UnableToGenerateIdError extends EntityStateError {
     super(`Unable to generate an ID.\n\tCause: ${cause}`);
   }
 }
+
+export class InvalidEntitySelectorError extends EntityStateError {
+  constructor(invalidSelector: any) {
+    super(`Cannot use ${invalidSelector} as EntitySelector`);
+  }
+}

--- a/src/tests/entity-state/action-handlers.spec.ts
+++ b/src/tests/entity-state/action-handlers.spec.ts
@@ -3,7 +3,7 @@ import { defaultEntityState, EntityState } from '../../lib/entity-state';
 import { EntityStateModel } from '../../lib/models';
 import { IdStrategy } from '../../lib/id-strategy';
 import { NGXS_META_KEY } from '../../lib/internal';
-import { UnableToGenerateIdError } from '../../lib/errors';
+import { UnableToGenerateIdError, InvalidEntitySelectorError } from '../../lib/errors';
 
 interface ToDo {
   title: string;
@@ -137,8 +137,27 @@ describe('EntityState action handlers', () => {
     });
   });
 
+  describe('updateAll', () => {
+    it('should update all entities', () => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
+        expect(val.entities).toEqual({
+          a: { title: 'a', test: 42 },
+          b: { title: 'b', test: 42 },
+          c: { title: 'c', test: 42 }
+        });
+      });
+
+      stateInstance.updateAll(context, {
+        payload: {
+          data: { test: 42 }
+        }
+      });
+    });
+  });
+
   describe('update', () => {
-    // update works with EntitySelector<T> = string | string[] | ((T) => boolean) | null;
+    // update works with EntitySelector<T> = string | string[] | ((T) => boolean);
     // update works with Updater<T> = Partial<T> | ((entity: Readonly<T>) => Partial<T>);
 
     describe('partial entity updates', () => {
@@ -163,7 +182,6 @@ describe('EntityState action handlers', () => {
       it('should update by multiple IDs', () => {
         const context = mockStateContext(undefined, (op: any) => {
           const val = op(state.todo);
-          console.log('val.entities:', val.entities);
           expect(val.entities).toEqual({
             a: { title: 'a', test: 42 },
             b: { title: 'b', test: 42 },
@@ -197,22 +215,16 @@ describe('EntityState action handlers', () => {
         });
       });
 
-      it('should update all with null', () => {
-        const context = mockStateContext(undefined, (op: any) => {
-          const val = op(state.todo);
-          expect(val.entities).toEqual({
-            a: { title: 'a', test: 42 },
-            b: { title: 'b', test: 42 },
-            c: { title: 'c', test: 42 }
-          });
-        });
-
-        stateInstance.update(context, {
-          payload: {
-            selector: null,
-            data: { test: 42 }
-          }
-        });
+      it('should throw an error when calling with null', () => {
+        const context = mockStateContext(undefined);
+        expect(() =>
+          stateInstance.update(context, {
+            payload: {
+              selector: null,
+              data: { test: 42 }
+            }
+          })
+        ).toThrowError(InvalidEntitySelectorError);
       });
 
       it('should update lastUpdated', () => {
@@ -223,7 +235,7 @@ describe('EntityState action handlers', () => {
 
         stateInstance.update(context, {
           payload: {
-            selector: null,
+            selector: entity => entity.title !== 'c',
             data: { test: 42 }
           }
         });
@@ -285,22 +297,17 @@ describe('EntityState action handlers', () => {
         });
       });
 
-      it('should update all with null', () => {
-        const context = mockStateContext(undefined, (op: any) => {
-          const val = op(state.todo);
-          expect(val.entities).toEqual({
-            a: { title: 'a', test: 42 },
-            b: { title: 'b', test: 42 },
-            c: { title: 'c', test: 42 }
-          });
-        });
+      it('should throw an error when called with null', () => {
+        const context = mockStateContext(undefined);
 
-        stateInstance.update(context, {
-          payload: {
-            selector: null,
-            data: () => ({ test: 42 })
-          }
-        });
+        expect(() =>
+          stateInstance.update(context, {
+            payload: {
+              selector: null,
+              data: () => ({ test: 42 })
+            }
+          })
+        ).toThrowError(InvalidEntitySelectorError);
       });
     });
   });
@@ -367,8 +374,20 @@ describe('EntityState action handlers', () => {
     });
   });
 
+  describe('removeAll', () => {
+    it('should remove all entities', () => {
+      const context = mockStateContext(undefined, (op: any) => {
+        const val = op(state.todo);
+        expect(val.active).toBeUndefined();
+        expect(val.entities).toEqual({});
+        expect(val.ids).toEqual([]);
+      });
+      stateInstance.removeAll(context);
+    });
+  });
+
   describe('remove', () => {
-    // remove works with EntitySelector<T> = string | string[] | ((T) => boolean) | null;
+    // remove works with EntitySelector<T> = string | string[] | ((T) => boolean);
 
     it('should remove by single ID', () => {
       const context = mockStateContext(undefined, (op: any) => {
@@ -407,14 +426,11 @@ describe('EntityState action handlers', () => {
       stateInstance.remove(context, { payload: entity => entity.title !== 'b' });
     });
 
-    it('should remove all with null', () => {
-      const context = mockStateContext(undefined, (op: any) => {
-        const val = op(state.todo);
-        expect(val.active).toBeUndefined();
-        expect(val.entities).toEqual({});
-        expect(val.ids).toEqual([]);
-      });
-      stateInstance.remove(context, { payload: null });
+    it('should throw an error when called with null', () => {
+      const context = mockStateContext(undefined);
+      expect(() => stateInstance.remove(context, { payload: null })).toThrowError(
+        InvalidEntitySelectorError
+      );
     });
 
     it('should update lastUpdated', () => {
@@ -423,7 +439,7 @@ describe('EntityState action handlers', () => {
         expect(val.lastUpdated).toBeCloseTo(Date.now(), -100); // within 100ms
       });
 
-      stateInstance.remove(context, { payload: null });
+      stateInstance.remove(context, { payload: ['a', 'c'] });
     });
   });
 

--- a/src/tests/entity-state/action-handlers.spec.ts
+++ b/src/tests/entity-state/action-handlers.spec.ts
@@ -3,7 +3,7 @@ import { defaultEntityState, EntityState } from '../../lib/entity-state';
 import { EntityStateModel } from '../../lib/models';
 import { IdStrategy } from '../../lib/id-strategy';
 import { NGXS_META_KEY } from '../../lib/internal';
-import { UnableToGenerateIdError, InvalidEntitySelectorError } from '../../lib/errors';
+import { UnableToGenerateIdError /* InvalidEntitySelectorError */ } from '../../lib/errors';
 
 interface ToDo {
   title: string;
@@ -224,7 +224,7 @@ describe('EntityState action handlers', () => {
               data: { test: 42 }
             }
           })
-        ).toThrowError(InvalidEntitySelectorError);
+        ).toThrowError(/* InvalidEntitySelectorError */);
       });
 
       it('should update lastUpdated', () => {
@@ -307,7 +307,7 @@ describe('EntityState action handlers', () => {
               data: () => ({ test: 42 })
             }
           })
-        ).toThrowError(InvalidEntitySelectorError);
+        ).toThrowError(/* InvalidEntitySelectorError */);
       });
     });
   });
@@ -428,9 +428,10 @@ describe('EntityState action handlers', () => {
 
     it('should throw an error when called with null', () => {
       const context = mockStateContext(undefined);
-      expect(() => stateInstance.remove(context, { payload: null })).toThrowError(
-        InvalidEntitySelectorError
-      );
+      expect(() => stateInstance.remove(context, { payload: null }))
+        .toThrowError
+        /* InvalidEntitySelectorError */
+        ();
     });
 
     it('should update lastUpdated', () => {


### PR DESCRIPTION
BREAKING CHANGE: using `null` as a selector will cause Remove and Update to throw an error

---

Closes #157 